### PR TITLE
Fix for the issue #169

### DIFF
--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -66,9 +66,8 @@ async def setup_bluetooth(
 
 def _lazy_install_awsiotsdk() -> None:
     custom_required_packages = ["awsiotsdk"]
-    links = "https://qqaatw.github.io/aws-crt-python-musllinux/"
     for pkg in custom_required_packages:
-        if not is_installed(pkg) and not install_package(pkg, find_links=links):
+        if not is_installed(pkg) and not install_package(pkg):
             raise RequirementsNotFound(DOMAIN, [pkg])
 
 


### PR DESCRIPTION
Fix for the issue #169 
the kwarg "find_links" is removed from homeassistant.util.package in the update https://github.com/home-assistant/core/commit/664e490cfaf76d29185dcd85b22c72c4f1e21dbc