### PR TITLE
Fix `TEMP_CELSIUS` deprecation warning.

### DIFF
--- a/custom_components/homewhiz/climate.py
+++ b/custom_components/homewhiz/climate.py
@@ -7,7 +7,7 @@ from homeassistant.components.climate import (  # type: ignore[import]
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -22,7 +22,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
 class HomeWhizClimateEntity(HomeWhizEntity, ClimateEntity):
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     def __init__(
         self,

--- a/custom_components/homewhiz/helper.py
+++ b/custom_components/homewhiz/helper.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dacite import from_dict
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 
 from custom_components.homewhiz import IdExchangeResponse
 from custom_components.homewhiz.api import ApplianceContents, ApplianceInfo
@@ -22,7 +22,7 @@ def build_entry_data(entry: ConfigEntry) -> EntryData:
 
 def unit_for_key(key: str) -> str | None:
     if "temp" in key:
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
     if "spin" in key:
         return "RPM"
     return None


### PR DESCRIPTION
Replaces usages of the now deprecated `TEMP_CELSIUS` constant with the recommended `UnitOfTemperature.CELSIUS` as per the deprecation warning seen in Home Assistant logs.

Fixes #184