### PR TITLE
97 requirement not found awsiotsdk awscrt raspberrypi os 32 bit docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Integration for devices that can connect to HomeWhiz mobile app (Beko, Grundig, 
 
 ## Installation
 
+⚠️ This integration depends on the awscrt Python package. This package is not directly available for ARM devices with 32 bit OS. More information can be found [here](https://github.com/home-assistant-HomeWhiz/home-assistant-HomeWhiz/issues/97).
+
 ### Option 1. Using HACS (Recommended)
 
 1. Search for `HomeWhiz` on the HACS integration page (this integration is part of the HACS default repository meaning it is not necessary to add this integration manually via custom repositories)

--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -10,8 +10,6 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.requirements import RequirementsNotFound
-from homeassistant.util.package import install_package, is_installed
 
 from .api import IdExchangeResponse
 from .bluetooth import HomewhizBluetoothUpdateCoordinator
@@ -64,16 +62,8 @@ async def setup_bluetooth(
     return True
 
 
-def _lazy_install_awsiotsdk() -> None:
-    custom_required_packages = ["awsiotsdk"]
-    for pkg in custom_required_packages:
-        if not is_installed(pkg) and not install_package(pkg):
-            raise RequirementsNotFound(DOMAIN, [pkg])
-
-
 async def setup_cloud(entry: ConfigEntry, hass: HomeAssistant) -> bool:
     _LOGGER.info("Setting up cloud connection")
-    _lazy_install_awsiotsdk()
 
     ids = from_dict(IdExchangeResponse, entry.data["ids"])
     cloud_config = from_dict(CloudConfig, entry.data["cloud_config"])

--- a/custom_components/homewhiz/manifest.json
+++ b/custom_components/homewhiz/manifest.json
@@ -15,9 +15,9 @@
   "dependencies": [
     "bluetooth_adapters"
   ],
-  "documentation": "https://github.com/rowysock/home-assistant-HomeWhiz",
+  "documentation": "https://github.com/home-assistant-HomeWhiz/home-assistant-HomeWhiz",
   "iot_class": "local_push",
-  "issue_tracker": "https://github.com/rowysock/home-assistant-HomeWhiz/issues",
+  "issue_tracker": "https://github.com/home-assistant-HomeWhiz/home-assistant-HomeWhiz/issues",
   "requirements": [
     "awsiotsdk",
     "bleak",

--- a/custom_components/homewhiz/manifest.json
+++ b/custom_components/homewhiz/manifest.json
@@ -19,6 +19,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rowysock/home-assistant-HomeWhiz/issues",
   "requirements": [
+    "awsiotsdk",
     "bleak",
     "bleak_retry_connector",
     "dacite",


### PR DESCRIPTION
While there is no fix for the missing aws dependencies for 32 bit ARM devices, this will remove the workaround which is not needed anymore.