### PR TITLE
156, 214, 216 (maybe 132) - Update and fix cloud connection

### DIFF
--- a/.github/workflows/pre-commit_ci.yml
+++ b/.github/workflows/pre-commit_ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
     - uses: pre-commit/action@v3.0.0
     - uses: pre-commit-ci/lite-action@v1.0.0
       if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
   hooks:
   - id: mypy
     additional_dependencies:
-    - aiohttp~=3.8.3
+    - aiohttp~=3.9.5
     - homeassistant-stubs
     - types-awscrt
     - voluptuous-stubs

--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from dacite import from_dict
@@ -86,7 +87,10 @@ def _lazy_install_awsiotsdk() -> None:
 
 async def setup_cloud(entry: ConfigEntry, hass: HomeAssistant) -> bool:
     _LOGGER.info("Setting up cloud connection")
-    _lazy_install_awsiotsdk()
+
+    loop = asyncio.get_event_loop()
+    lazy_install_awsiotsdk_task = loop.run_in_executor(None, _lazy_install_awsiotsdk)
+    await lazy_install_awsiotsdk_task
 
     ids = from_dict(IdExchangeResponse, entry.data["ids"])
     cloud_config = from_dict(CloudConfig, entry.data["cloud_config"])

--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -98,7 +98,8 @@ async def setup_cloud(entry: ConfigEntry, hass: HomeAssistant) -> bool:
         entry.entry_id
     ] = HomewhizCloudUpdateCoordinator(hass, ids.appId, cloud_config, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    hass.async_create_task(coordinator.connect())
+    entry.async_create_task(hass, coordinator.connect())
+    _LOGGER.info("Setup cloud connection successfully")
     return True
 
 

--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -40,6 +40,9 @@ async def setup_bluetooth(
 ) -> bool:
     _LOGGER.info("Setting up bluetooth connection")
 
+    if not entry.unique_id:
+        return False
+
     coordinator = hass.data.setdefault(DOMAIN, {})[
         entry.entry_id
     ] = HomewhizBluetoothUpdateCoordinator(hass, entry.unique_id)

--- a/custom_components/homewhiz/climate.py
+++ b/custom_components/homewhiz/climate.py
@@ -23,6 +23,8 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 class HomeWhizClimateEntity(HomeWhizEntity, ClimateEntity):
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    # https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/
+    _enable_turn_on_off_backwards_compatibility = False
 
     def __init__(
         self,
@@ -37,7 +39,9 @@ class HomeWhizClimateEntity(HomeWhizEntity, ClimateEntity):
     @property
     def supported_features(self) -> ClimateEntityFeature:
         features = (
-            ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+            ClimateEntityFeature.TARGET_TEMPERATURE
+            | ClimateEntityFeature.FAN_MODE
+            | ClimateEntityFeature.TURN_OFF
         )
         if self._control.swing.enabled:
             features |= ClimateEntityFeature.SWING_MODE

--- a/custom_components/homewhiz/cloud.py
+++ b/custom_components/homewhiz/cloud.py
@@ -237,12 +237,13 @@ class HomewhizCloudUpdateCoordinator(HomewhizCoordinator):
 
     @callback
     def handle_notify(self, payload: str) -> None:
+        _LOGGER.debug("Handling notify")
         message = from_dict(MqttPayload, json.loads(payload))
         offset = int(message.state.reported.wfaStartOffset)
         padding = [0 for _ in range(0, offset)]
         data = bytearray(padding + message.state.reported.wfa)
         _LOGGER.debug(f"Message received: {data}")
-        self.async_set_updated_data(data)
+        self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, data)
 
     @property
     def is_connected(self) -> bool:

--- a/custom_components/homewhiz/config_flow.py
+++ b/custom_components/homewhiz/config_flow.py
@@ -7,9 +7,8 @@ from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_discovered_service_info,
 )
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ADDRESS, CONF_ID, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
@@ -62,7 +61,7 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def async_step_bluetooth(
         self, discovery_info: BluetoothServiceInfoBleak
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the bluetooth discovery step."""
         await self.async_set_unique_id(discovery_info.address)
         self._abort_if_unique_id_configured()
@@ -74,7 +73,7 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         return self.async_show_menu(
             step_id="user",
             menu_options=["select_bluetooth_device", "provide_cloud_credentials"],
@@ -82,7 +81,7 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def async_step_select_bluetooth_device(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the user step to pick discovered device."""
         if user_input is not None:
             address = user_input[CONF_ADDRESS]
@@ -110,7 +109,7 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def async_step_bluetooth_connect(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """
         Handle the user step to provide HomeWhiz credentials.
         Credentials are used to fetch appliance config
@@ -170,7 +169,7 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def async_step_provide_cloud_credentials(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         errors = {}
         if user_input is not None:
             username = user_input[CONF_USERNAME]
@@ -200,7 +199,7 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
 
     async def async_step_select_cloud_device(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         assert self._cloud_credentials is not None
         if user_input is not None:
             assert self._cloud_appliances is not None

--- a/custom_components/homewhiz/tests/test_ac.py
+++ b/custom_components/homewhiz/tests/test_ac.py
@@ -90,10 +90,10 @@ def test_hvac_control(config: ApplianceConfiguration) -> None:
     hvac_control = ac_control.hvac_mode
 
     # Get mode when off
-    test_case.assertEquals(hvac_control.get_value(data_off), HVACMode.OFF)
+    test_case.assertEqual(hvac_control.get_value(data_off), HVACMode.OFF)
 
     # Get mode when in auto state
-    test_case.assertEquals(hvac_control.get_value(data_auto), HVACMode.AUTO)
+    test_case.assertEqual(hvac_control.get_value(data_auto), HVACMode.AUTO)
 
     # Turn on with the same mode
     test_case.assertListEqual(

--- a/custom_components/homewhiz/tests/test_advanced_ac.py
+++ b/custom_components/homewhiz/tests/test_advanced_ac.py
@@ -125,9 +125,9 @@ def test_swing_control(config: ApplianceConfiguration) -> None:
         [SWING_OFF, SWING_HORIZONTAL, SWING_VERTICAL, SWING_BOTH],
     )
 
-    test_case.assertEquals(swing_control.get_value(data_swing_off), SWING_OFF)
-    test_case.assertEquals(swing_control.get_value(data_swing_both), SWING_BOTH)
-    test_case.assertEquals(
+    test_case.assertEqual(swing_control.get_value(data_swing_off), SWING_OFF)
+    test_case.assertEqual(swing_control.get_value(data_swing_both), SWING_BOTH)
+    test_case.assertEqual(
         swing_control.get_value(data_swing_horizontal), SWING_HORIZONTAL
     )
 


### PR DESCRIPTION
Fixes #214, #216, #156 (hopefully).
Possible fixes #132 

Also improves:
- Move blocking calls to executor to avoid slowing down Home Assistant (and preventing warnings)
- Update cloud connection reconnect logic to avoid reconnecting before expiration
- Use Python3.12 for GitHub pipelines to fix pipeline failure