### PR TITLE
Fix race condition in BT coordinator

### DIFF
--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -44,47 +44,52 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         self._accumulator = MessageAccumulator()
         self._hass = hass
         self._device: BLEDevice | None = None
+        self._device_lock = asyncio.Lock()
         self._connection: BleakClient | None = None
+        self._connection_lock = asyncio.Lock()
         self.alive = True
         # To ensure that only one reconnect is performed at a time
         self._reconnecting = False
+        self._reconnecting_lock = asyncio.Lock()
         # Allow users to configure regular Bluetooth reconnections
         self._reconnect_interval: int | None = reconnect_interval
         self._reconnect_interval_task: None | Callable = None
         super().__init__(hass, _LOGGER, name=DOMAIN)
 
     async def connect(self) -> bool:
-        _LOGGER.info("Connecting to %s", self.address)
-        self._device = bluetooth.async_ble_device_from_address(
-            self._hass, self.address, connectable=True
-        )
-        # Self connection should be None
-        if self._connection:
-            _LOGGER.warning("Trying to connect even though connection already exists!")
-        if not self._device:
-            raise Exception(f"Device not found for address {self.address}")
+        async with self._connection_lock:
+            _LOGGER.info(f"Connecting to {self.address}")
+            async with self._device_lock:
+                self._device = bluetooth.async_ble_device_from_address(
+                    self._hass, self.address, connectable=True
+                )
+                # Self connection should be None
+                if self._connection:
+                    _LOGGER.warning("Trying to connect even though connection already exists!")
+                if not self._device:
+                    raise Exception(f"Device not found for address {self.address}")
 
-        # How to clear disconnected_callback?
-        _LOGGER.debug("Establishing connection")
-        self._connection = await establish_connection(
-            client_class=BleakClient,
-            device=self._device,
-            disconnected_callback=self.disconnected_callback,
-            name=self.address,
-        )
-        if not self._connection.is_connected:
-            raise Exception("Can't connect")
-        _LOGGER.debug("Starting notify")
-        await self._connection.start_notify(
-            "0000ac02-0000-1000-8000-00805f9b34fb",
-            lambda sender, message: self.hass.create_task(self.handle_notify(message)),
-        )
-        _LOGGER.debug("Sending initial command")
-        await self._connection.write_gatt_char(
-            "0000ac01-0000-1000-8000-00805f9b34fb",
-            bytearray.fromhex("02 04 00 04 00 1a 01 03"),
-            response=False,
-        )
+                # How to clear disconnected_callback?
+                _LOGGER.debug("Establishing connection")
+                self._connection = await establish_connection(
+                    client_class=BleakClient,
+                    device=self._device,
+                    disconnected_callback=self.disconnected_callback,
+                    name=self.address,
+                )
+                if not self._connection.is_connected:
+                    raise Exception("Can't connect")
+            _LOGGER.debug("Starting notify")
+            await self._connection.start_notify(
+                "0000ac02-0000-1000-8000-00805f9b34fb",
+                lambda sender, message: self.hass.create_task(self.handle_notify(message)),
+            )
+            _LOGGER.debug("Sending initial command")
+            await self._connection.write_gatt_char(
+                "0000ac01-0000-1000-8000-00805f9b34fb",
+                bytearray.fromhex("02 04 00 04 00 1a 01 03"),
+                response=False,
+            )
 
         # To retrieve RSSI value
         # https://developers.home-assistant.io/docs/core/bluetooth/api/#fetching-the-latest-bluetoothserviceinfobleak-for-a-device
@@ -140,42 +145,45 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
             self.hass.create_task(self._connection.disconnect())
 
     async def try_reconnect(self) -> None:
-        _LOGGER.debug("[%s] Trying to reconnect", self.address)
-        if self._reconnecting:
-            _LOGGER.warning("Stopping reconnect as reconnect is already in progress")
-            return
-        while self.alive and not self.is_connected:
-            self._reconnecting = True
-            if not bluetooth.async_address_present(
-                self.hass, self.address, connectable=True
-            ):
-                _LOGGER.info(
-                    "Device not found. "
-                    "Will reconnect automatically when the device becomes available"
-                )
-                self._reconnecting = False
+        async with self._reconnecting_lock:
+            _LOGGER.debug(f"[{self.address}] Trying to reconnect")
+            if self._reconnecting:
+                _LOGGER.warning("Stopping reconnect as reconnect is already in progress")
                 return
-            try:
-                _LOGGER.debug("[%s] Establish connection from reconnect", self.address)
-                await self.connect()
-                # Reconnect was successful!
-                _LOGGER.debug("Reconnecting was successful!")
-                self._reconnecting = False
-            except Exception:
-                _LOGGER.exception("Can't reconnect. Waiting 30 seconds to try again")
-                await asyncio.sleep(30)
+            while self.alive and not self.is_connected:
+                self._reconnecting = True
+                if not bluetooth.async_address_present(
+                    self.hass, self.address, connectable=True
+                ):
+                    _LOGGER.info(
+                        "Device not found. "
+                        "Will reconnect automatically when the device becomes available"
+                    )
+                    self._reconnecting = False
+                    return
+                try:
+                    _LOGGER.debug(f"[{self.address}] Establish connection from reconnect")
+                    await self.connect()
+                    # Reconnect was successful!
+                    _LOGGER.debug("Reconnecting was successful!")
+                    self._reconnecting = False
+                except Exception:
+                    _LOGGER.exception("Can't reconnect. Waiting 30 seconds to try again")
+                    await asyncio.sleep(30)
 
     async def handle_disconnect(self, *args: Any) -> None:
         _LOGGER.debug("Handling disconnect%s...", " by time interval" if args else "")
-        self._device = None
-        # Ensure device is disconnected
-        if self._connection:
-            _LOGGER.info("Triggering disconnect")
-            await self._connection.disconnect()
-        self.hass.add_job(self.async_set_updated_data, None)
-        self._connection = None
-        _LOGGER.info("[%s] Disconnected", self.address)
-        self.hass.create_task(self.try_reconnect())
+        async with self._connection_lock:
+            async with self._device_lock:
+                self._device = None
+            # Ensure device is disconnected
+            if self._connection:
+                _LOGGER.info("Triggering disconnect")
+                await self._connection.disconnect()
+            self.hass.add_job(self.async_set_updated_data, None)
+            self._connection = None
+            _LOGGER.info(f"[{self.address}] Disconnected")
+            self.hass.create_task(self.try_reconnect())
 
     @callback
     async def handle_notify(self, message: bytearray) -> None:
@@ -192,24 +200,26 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
             self.async_set_updated_data(full_message)
 
     async def send_command(self, command: Command) -> None:
-        _LOGGER.debug("Sending command %s:%s", command.index, command.value)
-        payload = bytearray([2, 4, 0, 4, 0, command.index, 1, command.value])
-        assert self._connection is not None
-        await self._connection.write_gatt_char(
-            "0000ac01-0000-1000-8000-00805F9B34FB",
-            payload,
-        )
-        _LOGGER.debug("Command sent")
+        _LOGGER.debug(f"Sending command {command.index}:{command.value}")
+        async with self._connection_lock:
+            payload = bytearray([2, 4, 0, 4, 0, command.index, 1, command.value])
+            assert self._connection is not None
+            await self._connection.write_gatt_char(
+                "0000ac01-0000-1000-8000-00805F9B34FB",
+                payload,
+            )
+            _LOGGER.debug("Command sent")
 
     @property
     def is_connected(self) -> bool:
         return self._connection is not None and self._connection.is_connected
 
     async def kill(self) -> None:
-        _LOGGER.debug("[%s] Killing connection", self.address)
-        self.alive = False
-        if self._connection is not None:
-            await self._connection.disconnect()
-        if self._reconnect_interval_task:
-            self._reconnect_interval_task()
-        _LOGGER.debug("[%s] Connection killed", self.address)
+        _LOGGER.debug(f"[{self.address}] Killing connection")
+        async with self._connection_lock:
+            self.alive = False
+            if self._connection is not None:
+                await self._connection.disconnect()
+            if self._reconnect_interval_task:
+                self._reconnect_interval_task()
+            _LOGGER.debug(f"[{self.address}] Connection killed")

--- a/custom_components/homewhiz/manifest.json
+++ b/custom_components/homewhiz/manifest.json
@@ -26,5 +26,5 @@
     "aiohttp",
     "bidict"
   ],
-  "version": "v0.5.8"
+  "version": "v0.5.9"
 }

--- a/custom_components/homewhiz/manifest.json
+++ b/custom_components/homewhiz/manifest.json
@@ -26,5 +26,5 @@
     "aiohttp",
     "bidict"
   ],
-  "version": "v0.5.9"
+  "version": "v0.5.8"
 }


### PR DESCRIPTION
Fixes #285 in situations where BT is still active on the machine but a (re-)connect fails.
The PR resolves a general problem in the BT coordinator, which was only noticed in this specific case.