### PR TITLE
Fix 500 Internal Server Error  on configuration dialog

### DIFF
--- a/custom_components/homewhiz/config_flow.py
+++ b/custom_components/homewhiz/config_flow.py
@@ -289,7 +289,7 @@ class BluetoothOptionsFlowHandler(OptionsFlow):
             self.hass.config_entries.async_update_entry(
                 self._config_entry, options=user_input
             )
-            await self.hass.config_entries.async_reload(self._config_entry.entry_id)
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
@@ -299,7 +299,7 @@ class BluetoothOptionsFlowHandler(OptionsFlow):
                     vol.Optional(
                         CONF_BT_RECONNECT_INTERVAL,
                         description={
-                            "suggested_value": self._config_entry.options.get(
+                            "suggested_value": self.config_entry.options.get(
                                 CONF_BT_RECONNECT_INTERVAL, None
                             )
                         },


### PR DESCRIPTION
Solve the error, which appears when using configuration dialog:

<img width="562" height="197" alt="Bildschirmfoto vom 2025-09-01 09-03-00" src="https://github.com/user-attachments/assets/0dc57216-e169-4f43-ba1e-5a3c393cac7e" />
