### PR TITLE
Fix "Unknown error" when applying configuration dialog

### DIFF
--- a/custom_components/homewhiz/config_flow.py
+++ b/custom_components/homewhiz/config_flow.py
@@ -287,7 +287,7 @@ class BluetoothOptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             _LOGGER.debug("Reloading entries after updating options: %s", user_input)
             self.hass.config_entries.async_update_entry(
-                self._config_entry, options=user_input
+                self.config_entry, options=user_input
             )
             await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             return self.async_create_entry(title="", data=user_input)


### PR DESCRIPTION
fixes a second typo for `self.config_entry` which causes an "Unknown error" when applying configuration dialog:

<img width="400" height="343" alt="Bildschirmfoto vom 2025-09-09 10-50-47" src="https://github.com/user-attachments/assets/25524408-c208-4ba7-85ce-e5407920d2e4" />
