### PR TITLE
Fix unhashable type error in ApplianceInfo

### DIFF
--- a/custom_components/homewhiz/api.py
+++ b/custom_components/homewhiz/api.py
@@ -77,7 +77,7 @@ class ApplianceInfo:
     connectivity: str = "BT"
 
     def is_bt(self) -> bool:
-        return self in {"BT", "BASICBT"}
+        return self.connectivity in {"BT", "BASICBT"}
 
 
 @dataclass


### PR DESCRIPTION
Fixes #308 (introduced with the enforcement of certain Ruff rules)