### PR TITLE
Fix: Hide sensors reporting invalid 0 duration (Bauknecht dryer fix)

### DIFF
--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -87,7 +87,14 @@ async def async_setup_entry(
         c
         for c in controls
         if isinstance(
-            c, (TimeControl, EnumControl, NumericControl, DebugControl, SummedTimestampControl)
+            c,
+            (
+                TimeControl,
+                EnumControl,
+                NumericControl,
+                DebugControl,
+                SummedTimestampControl,
+            ),
         )
     ]
     _LOGGER.debug("Sensors: %s", sensor_controls)


### PR DESCRIPTION
This PR fixes an issue where Bauknecht dryers report 0 as duration for the end_time sensor, which is confusing. The fix checks for 0 duration and returns None/Unavailable instead.Tested on model 7188239270