### PR TITLE
Use warning emojis instead of shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ logger:
     custom_components.homewhiz: debug
 ```
 To retrieve logs, navigate in Home Assistant to: settings -> system -> logs and retrieve logs by e.g. pressing the download button below the logs.
-> :warning: Please review your logs and **delete personal and private information before posting** :warning:
+> ⚠️ Please review your logs and **delete personal and private information before posting** ⚠️
 
 ## Contributing to the project
 


### PR DESCRIPTION
Use warning emojis to render nicer in Home Assistant

Using `:warning:` does not render correctly in Home Assistant

<img width="900" height="63" alt="image" src="https://github.com/user-attachments/assets/8bdf4db5-d4b1-4044-84e9-aa54f429e46e" />

