### PR TITLE
Fix additional race conditions and potential BT disconnects

### DIFF
--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -57,7 +57,7 @@ async def setup_bluetooth(
         service_info: BluetoothServiceInfoBleak,
         change: BluetoothChange,
     ) -> None:
-        if not coordinator.is_connected and not coordinator._reconnecting_lock.locked():
+        if not coordinator.is_connected and not coordinator.reconnecting_lock.locked():
             _LOGGER.debug("Called connect callback in setup_bluetooth")
             hass.async_create_task(coordinator.connect())
 

--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -57,8 +57,9 @@ async def setup_bluetooth(
         service_info: BluetoothServiceInfoBleak,
         change: BluetoothChange,
     ) -> None:
-        _LOGGER.debug("Called connect callback in setup_bluetooth")
-        hass.async_create_task(coordinator.connect())
+        if not coordinator.is_connected and not coordinator._reconnecting_lock.locked():
+            _LOGGER.debug("Called connect callback in setup_bluetooth")
+            hass.async_create_task(coordinator.connect())
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/custom_components/homewhiz/api.py
+++ b/custom_components/homewhiz/api.py
@@ -260,7 +260,10 @@ async def make_api_get_request(
             except ContentTypeError as err:
                 text = await response.text()
                 _LOGGER.error(text)
-                raise RequestError(text) from err
+                _handle_request_error(text, err)
+
+    def _handle_request_error(text: str, err: Exception) -> None:
+        raise RequestError(text) from err
 
 
 async def fetch_contents_index(

--- a/custom_components/homewhiz/api.py
+++ b/custom_components/homewhiz/api.py
@@ -186,6 +186,10 @@ async def make_api_get_request(
     canonical_uri: str,
     canonical_querystring: str = "",
 ) -> Any:
+
+    def _handle_request_error(text: str, err: Exception) -> None:
+        raise RequestError(text) from err
+
     t = datetime.datetime.now(tz=datetime.UTC)
     amz_date = t.strftime("%Y%m%dT%H%M%SZ")
     # Date w/o time, used in credential scope
@@ -260,10 +264,7 @@ async def make_api_get_request(
             except ContentTypeError as err:
                 text = await response.text()
                 _LOGGER.error(text)
-                _handle_request_error(text, err)
-
-    def _handle_request_error(text: str, err: Exception) -> None:
-        raise RequestError(text) from err
+                return _handle_request_error(text, err)  # Add explicit return
 
 
 async def fetch_contents_index(

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -239,8 +239,8 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
 
     async def kill(self) -> None:
         _LOGGER.debug("[%s] Killing connection", self.address)
+        self.alive = False   # set FIRST, before calling disconnect()
         async with self._connection_lock:
-            self.alive = False
             if self._connection is not None:
                 await self._connection.disconnect()
             if self._reconnect_interval_task:

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -203,7 +203,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         _LOGGER.info("[%s] Disconnected", self.address)
         self.hass.create_task(self.try_reconnect())
 
-    @callback
+    # @callback removed – the function is invoked via create_task, not called directly
     async def handle_notify(self, message: bytearray) -> None:
         _LOGGER.debug("Message received: %s", message)
         if len(message) < 10:

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -96,7 +96,8 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 )
             try:
                 if not self._connection.is_connected:
-                    raise RuntimeError("Can't connect")
+                    msg = "Can't connect"
+                    raise RuntimeError(msg)
 
                 await asyncio.sleep(0.5)
 

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -94,10 +94,14 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                     disconnected_callback=self.disconnected_callback,
                     name=self.address,
                 )
+
+            def _raise_cant_connect() -> None:
+                msg = "Can't connect"
+                raise RuntimeError(msg)
+
             try:
                 if not self._connection.is_connected:
-                    msg = "Can't connect"
-                    raise RuntimeError(msg)
+                    _raise_cant_connect()
 
                 await asyncio.sleep(0.5)
 

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 from collections.abc import Callable
 from datetime import datetime, timedelta
@@ -8,6 +9,7 @@ from bleak import BleakClient, BLEDevice
 from bleak_retry_connector import establish_connection
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_point_in_time
 
 from .const import DOMAIN
@@ -17,7 +19,7 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
 class MessageAccumulator:
-    def __init__(self):
+    def __init__(self) -> None:
         self._expected_index = 0
         self._accumulated: bytearray = bytearray()
 
@@ -80,7 +82,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                         "Trying to connect even though connection already exists!"
                     )
                 if not self._device:
-                    raise Exception(f"Device not found for address {self.address}")
+                    raise RuntimeError(f"Device not found for address {self.address}")
 
                 # How to clear disconnected_callback?
                 _LOGGER.debug("Establishing connection")
@@ -92,7 +94,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 )
             try:
                 if not self._connection.is_connected:
-                    raise Exception("Can't connect")
+                    raise RuntimeError("Can't connect")
 
                 await asyncio.sleep(0.5)
 
@@ -111,10 +113,8 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 )
             except Exception:
                 _LOGGER.exception("Failed to set up connection, cleaning up")
-                try:
+                with contextlib.suppress(Exception):
                     await self._connection.disconnect()
-                except Exception:
-                    pass
                 self._connection = None   # ensure clean state for next attempt
                 raise
 
@@ -173,7 +173,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         if self.alive:
             connection = self._connection  # capture a local reference atomically
             if connection is not None:
-                self.hass.create_task(self._connection.disconnect())
+                self.hass.create_task(connection.disconnect())
 
     async def try_reconnect(self) -> None:
         async with self._reconnecting_lock:

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -172,7 +172,8 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                         "Device not found. "
                         "Will reconnect automatically when the device becomes available"
                     )
-                    return
+                    await asyncio.sleep(60)
+                    continue   # instead of return
                 try:
                     _LOGGER.debug(
                         "[%s] Establish connection from reconnect",

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -35,7 +35,9 @@ class MessageAccumulator:
             return full_message
         else:
             # Unexpected sequence: reset to avoid getting permanently stuck
-            _LOGGER.warning("Unexpected message index %d, resetting accumulator", message_index)
+            _LOGGER.warning(
+                "Unexpected message index %d, resetting accumulator", message_index
+            )
             self._expected_index = 0
             self._accumulated = bytearray()
         return None
@@ -68,7 +70,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
             _LOGGER.debug("Already connected, skipping connect()")
             return True
         async with self._connection_lock:
-            if self.is_connected:   # double-checked locking
+            if self.is_connected:  # double-checked locking
                 _LOGGER.debug("Already connected, skipping connect()")
                 return True
             _LOGGER.info("Connecting to %s", self.address)
@@ -115,7 +117,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 _LOGGER.exception("Failed to set up connection, cleaning up")
                 with contextlib.suppress(Exception):
                     await self._connection.disconnect()
-                self._connection = None   # ensure clean state for next attempt
+                self._connection = None  # ensure clean state for next attempt
                 raise
 
         # To retrieve RSSI value
@@ -176,7 +178,6 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 self.hass.create_task(connection.disconnect())
 
     async def try_reconnect(self) -> None:
-        # noqa: SLF001
         async with self.reconnecting_lock:
             _LOGGER.debug("[%s] Trying to reconnect", self.address)
             while self.alive and not self.is_connected:
@@ -188,7 +189,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                         "Will reconnect automatically when the device becomes available"
                     )
                     await asyncio.sleep(60)
-                    continue   # instead of return
+                    continue  # instead of return
                 try:
                     _LOGGER.debug(
                         "[%s] Establish connection from reconnect",
@@ -255,7 +256,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
 
     async def kill(self) -> None:
         _LOGGER.debug("[%s] Killing connection", self.address)
-        self.alive = False   # set FIRST, before calling disconnect()
+        self.alive = False  # set FIRST, before calling disconnect()
         async with self._connection_lock:
             if self._connection is not None:
                 await self._connection.disconnect()

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -211,12 +211,18 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
     async def send_command(self, command: Command) -> None:
         _LOGGER.debug("Sending command %s:%s", command.index, command.value)
         async with self._connection_lock:
+            if self._connection is None or not self._connection.is_connected:
+                _LOGGER.warning("Cannot send command: not connected")
+                raise HomeAssistantError("Device not connected")
             payload = bytearray([2, 4, 0, 4, 0, command.index, 1, command.value])
-            assert self._connection is not None
-            await self._connection.write_gatt_char(
-                "0000ac01-0000-1000-8000-00805F9B34FB",
-                payload,
-            )
+            try:
+                await self._connection.write_gatt_char(
+                    "0000ac01-0000-1000-8000-00805F9B34FB",
+                    payload,
+                )
+            except Exception as e:
+                _LOGGER.error("Failed to send command: %s", e)
+                raise
             _LOGGER.debug("Command sent")
 
     @property

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -112,8 +112,10 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         service_info = bluetooth.async_last_service_info(
             self.hass, self.address, connectable=True
         )
-        assert service_info is not None
-        _LOGGER.info("Successfully connected. RSSI: %s", service_info.rssi)
+        if service_info is not None:
+            _LOGGER.info("Successfully connected. RSSI: %s", service_info.rssi)
+        else:
+            _LOGGER.info("Successfully connected (RSSI not available)")
 
         # If reconnection is configured, set a task to reconnect after interval
         if self._reconnect_interval:

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -90,21 +90,33 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                     disconnected_callback=self.disconnected_callback,
                     name=self.address,
                 )
+            try:
                 if not self._connection.is_connected:
                     raise Exception("Can't connect")
-            _LOGGER.debug("Starting notify")
-            await self._connection.start_notify(
-                "0000ac02-0000-1000-8000-00805f9b34fb",
-                lambda sender, message: self.hass.create_task(
-                    self.handle_notify(message)
-                ),
-            )
-            _LOGGER.debug("Sending initial command")
-            await self._connection.write_gatt_char(
-                "0000ac01-0000-1000-8000-00805f9b34fb",
-                bytearray.fromhex("02 04 00 04 00 1a 01 03"),
-                response=False,
-            )
+
+                await asyncio.sleep(0.5)
+
+                _LOGGER.debug("Starting notify")
+                await self._connection.start_notify(
+                    "0000ac02-0000-1000-8000-00805f9b34fb",
+                    lambda sender, message: self.hass.create_task(
+                        self.handle_notify(message)
+                    ),
+                )
+                _LOGGER.debug("Sending initial command")
+                await self._connection.write_gatt_char(
+                    "0000ac01-0000-1000-8000-00805f9b34fb",
+                    bytearray.fromhex("02 04 00 04 00 1a 01 03"),
+                    response=False,
+                )
+            except Exception:
+                _LOGGER.exception("Failed to set up connection, cleaning up")
+                try:
+                    await self._connection.disconnect()
+                except Exception:
+                    pass
+                self._connection = None   # ensure clean state for next attempt
+                raise
 
         # To retrieve RSSI value
         # https://developers.home-assistant.io/docs/core/bluetooth/api/#fetching-the-latest-bluetoothserviceinfobleak-for-a-device

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -57,7 +57,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         self._connection_lock = asyncio.Lock()
         self.alive = True
         # To ensure that only one reconnect is performed at a time
-        self._reconnecting_lock = asyncio.Lock()
+        self.reconnecting_lock = asyncio.Lock()
         # Allow users to configure regular Bluetooth reconnections
         self._reconnect_interval: int | None = reconnect_interval
         self._reconnect_interval_task: None | Callable = None
@@ -176,7 +176,8 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 self.hass.create_task(connection.disconnect())
 
     async def try_reconnect(self) -> None:
-        async with self._reconnecting_lock:
+        # noqa: SLF001
+        async with self.reconnecting_lock:
             _LOGGER.debug("[%s] Trying to reconnect", self.address)
             while self.alive and not self.is_connected:
                 if not bluetooth.async_address_present(

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -156,8 +156,10 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
     def reconnect_callback(self, *args: Any) -> None:
         # Trigger a disconnect, the disconnected_callback will trigger the reconnect
         _LOGGER.debug("Reconnect callback")
-        if self.alive and self._connection:
-            self.hass.create_task(self._connection.disconnect())
+        if self.alive:
+            connection = self._connection  # capture a local reference atomically
+            if connection is not None:
+                self.hass.create_task(self._connection.disconnect())
 
     async def try_reconnect(self) -> None:
         async with self._reconnecting_lock:

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -184,8 +184,9 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 await self._connection.disconnect()
             self.hass.add_job(self.async_set_updated_data, None)
             self._connection = None
-            _LOGGER.info("[%s] Disconnected", self.address)
-            self.hass.create_task(self.try_reconnect())
+        # Spawn the task AFTER releasing the lock
+        _LOGGER.info("[%s] Disconnected", self.address)
+        self.hass.create_task(self.try_reconnect())
 
     @callback
     async def handle_notify(self, message: bytearray) -> None:

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -62,7 +62,13 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         super().__init__(hass, _LOGGER, name=DOMAIN)
 
     async def connect(self) -> bool:
+        if self.is_connected:
+            _LOGGER.debug("Already connected, skipping connect()")
+            return True
         async with self._connection_lock:
+            if self.is_connected:   # double-checked locking
+                _LOGGER.debug("Already connected, skipping connect()")
+                return True
             _LOGGER.info("Connecting to %s", self.address)
             async with self._device_lock:
                 self._device = bluetooth.async_ble_device_from_address(

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -17,19 +17,25 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
 class MessageAccumulator:
-    expected_index = 0
-    accumulated: bytearray = bytearray()
+    def __init__(self):
+        self._expected_index = 0
+        self._accumulated: bytearray = bytearray()
 
     def accumulate_message(self, message: bytearray) -> bytearray | None:
         message_index = message[4]
         _LOGGER.debug("Message index: %d", message_index)
         if message_index == 0:
-            self.accumulated = message[7:]
-            self.expected_index = 1
-        elif self.expected_index == 1:
-            full_message = self.accumulated + message[7:]
-            self.expected_index = 0
+            self._accumulated = message[7:]
+            self._expected_index = 1
+        elif message_index == 1 and self._expected_index == 1:
+            full_message = self._accumulated + message[7:]
+            self._expected_index = 0
             return full_message
+        else:
+            # Unexpected sequence: reset to avoid getting permanently stuck
+            _LOGGER.warning("Unexpected message index %d, resetting accumulator", message_index)
+            self._expected_index = 0
+            self._accumulated = bytearray()
         return None
 
 

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -41,9 +41,12 @@ from custom_components.homewhiz.appliance_controls import (
 
 async def get_file(url: str) -> Any:
     """Get JSON file from url"""
-    async with aiohttp.ClientSession() as session, session.get(
-        url,
-    ) as response:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(
+            url,
+        ) as response,
+    ):
         return json.loads(await response.text())
 
 

--- a/scripts/generate_translations.py
+++ b/scripts/generate_translations.py
@@ -41,11 +41,10 @@ from custom_components.homewhiz.appliance_controls import (
 
 async def get_file(url: str) -> Any:
     """Get JSON file from url"""
-    async with aiohttp.ClientSession() as session:
-        async with session.get(
-            url,
-        ) as response:
-            return json.loads(await response.text())
+    async with aiohttp.ClientSession() as session, session.get(
+        url,
+    ) as response:
+        return json.loads(await response.text())
 
 
 API_LANGUAGES = {


### PR DESCRIPTION
The following fixes resolve some remaining race conditions:

- Fix deadlock risk in handle_disconnect()
Issue: `handle_disconnect` holds `_connection_lock` while spawning `try_reconnect` as a task. `try_reconnect` calls `connect`, which in turn tries to acquire `_connection_lock`.
One-line change, prevents zombie reconnects on shutdown.

- Fix thread-unsafe and broken state handling
Issue: `MessageAccumulator` is not thread-safe and has broken state handling.
`MessageAccumulator.expected_index` and `accumulated` are class attributes, not instance attributes. While there is only one instance per coordinator in practice, this is a fragile design that will silently misbehave if ever instantiated more than once.
Additional issue: race between BLE callback and asyncio.
The BLE notify callback arrives from the Bleak thread and is handed off via `hass.create_task(self.handle_notify(message))`. Under rapid message delivery, multiple `handle_notify` tasks can queue up and execute out of order, breaking the sequence logic of `MessageAccumulator`.

- Fix clean exception for AssertionError raises
Issue: `send_command` raises `AssertionError` on disconnect instead of a clean exception

- Fix possible multiple parallel connect() calls
Issue: Multiple parallel `connect()` calls triggered by Bluetooth callbacks.
The `async_register_callback` mechanism can fire repeatedly – e.g. on each BLE advertisement packet or RSSI change. Every invocation creates a new `coordinator.connect()` task. While `_connection_lock` prevents parallel execution, there is no guard to detect that a connection already exists.

- Fix accesses self._connection without a lock
Issue: reconnect_callback accesses `_connection` without a lock.

- Fix race condition allows unintended reconnection
Issue: `alive = False` is set too late in `kill()`, allowing a spurious reconnect.

- Fix permanetly give up when device not found
Issue: `try_reconnect` gives up permanently when the device is not visible

- Fix unnecessary callback for handle_notify
Issue: `handle_notify` is declared async but decorated with `@callback`:
`@callback` in Home Assistant is intended for synchronous functions and disables certain safety checks. Decorating an `async` function with `@callback` is semantically incorrect. The function still runs correctly as a coroutine because it is invoked via `create_task`.

- Fix possible crash after successfull connect
Issue: `async_last_service_info` can return None if the service info has expired from the cache shortly after the connection was established. An AssertionError here aborts the setup process even though a valid BLE connection is already active.

- Fix possible BLE device not ready errors
Issue: The exception from `start_notify` does not release the `_connection_lock` properly and leaves `_connection` in the locked state, even though no actual connection exists.
Whenever an error occurs after `establish_connection`, `self._connection` is set to `None`, so that `is_connected` correctly returns `False` and `try_reconnect` finds a clean state.