### PR TITLE
Stop BLE connection flapping with ESPHome proxies (#367)

### DIFF
--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -10,12 +10,46 @@ from bleak_retry_connector import establish_connection
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.event import async_call_later, async_track_point_in_time
 
 from .const import DOMAIN
 from .homewhiz import Command, HomewhizCoordinator
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+# GATT characteristics exposed by HomeWhiz appliances
+NOTIFY_CHARACTERISTIC = "0000ac02-0000-1000-8000-00805f9b34fb"
+COMMAND_CHARACTERISTIC = "0000ac01-0000-1000-8000-00805f9b34fb"
+# Handshake written immediately after subscribing to notifications
+INIT_COMMAND = bytearray.fromhex("02 04 00 04 00 1a 01 03")
+
+# HomeWhiz appliances frequently terminate the link within a few hundred
+# milliseconds of accepting it - before notifications can be enabled - so the
+# subscribe step fails with "Not connected" / a dropped-connection error even
+# though establish_connection() succeeded. Retry the whole establish+subscribe
+# sequence a handful of times in quick succession before falling back to the
+# slower background reconnect loop.
+_SETUP_MAX_ATTEMPTS = 4
+_SETUP_RETRY_DELAY = 1.0
+
+# ESP32 BLE proxies periodically drop the link with a supervision timeout
+# (HCI 0x08) due to WiFi/BLE radio coexistence, even on a strong signal. These
+# blips self-heal in ~1-2s, so don't flap entities unavailable on every drop -
+# only mark unavailable if the connection stays down past this grace period.
+_DISCONNECT_GRACE_SECONDS = 60
+
+# A control command may arrive during one of those brief blips (entities stay
+# available across them), so wait briefly for the in-flight reconnect before
+# giving up, and retry the write if the link drops mid-command.
+_COMMAND_CONNECT_TIMEOUT = 20
+_COMMAND_MAX_ATTEMPTS = 2
+
+# Backoff for the background reconnect loop (seconds). A short initial delay
+# re-grabs the (often single) proxy connection slot before the advertisement
+# goes stale; the delay grows on repeated failure up to the cap.
+_RECONNECT_INITIAL_DELAY = 3
+_RECONNECT_MAX_DELAY = 60
+_RECONNECT_ABSENT_DELAY = 30
 
 
 class MessageAccumulator:
@@ -63,6 +97,13 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         # Allow users to configure regular Bluetooth reconnections
         self._reconnect_interval: int | None = reconnect_interval
         self._reconnect_interval_task: None | Callable = None
+        # Time the live connection was opened (used to log how long each
+        # connection is held before it drops).
+        self._connected_at: datetime | None = None
+        # Debounced availability: stays True across brief reconnect blips, only
+        # flips False once the connection has been down for the grace period.
+        self._available = False
+        self._grace_unsub: Callable | None = None
         super().__init__(hass, _LOGGER, name=DOMAIN)
 
     async def connect(self) -> bool:
@@ -74,54 +115,19 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 _LOGGER.debug("Already connected, skipping connect()")
                 return True
             _LOGGER.info("Connecting to %s", self.address)
-            async with self._device_lock:
-                self._device = bluetooth.async_ble_device_from_address(
-                    self._hass, self.address, connectable=True
+            # A stale (disconnected) client may still be referenced - drop it
+            # before opening a fresh connection so we never leak a proxy slot.
+            if self._connection is not None:
+                _LOGGER.warning(
+                    "Trying to connect even though connection already exists!"
                 )
-                # Self connection should be None
-                if self._connection:
-                    _LOGGER.warning(
-                        "Trying to connect even though connection already exists!"
-                    )
-                if not self._device:
-                    raise RuntimeError(f"Device not found for address {self.address}")
-
-                # How to clear disconnected_callback?
-                _LOGGER.debug("Establishing connection")
-                self._connection = await establish_connection(
-                    client_class=BleakClient,
-                    device=self._device,
-                    disconnected_callback=self.disconnected_callback,
-                    name=self.address,
-                )
-
-            def _raise_cant_connect() -> None:
-                msg = "Can't connect"
-                raise RuntimeError(msg)
-
-            try:
-                if not self._connection.is_connected:
-                    _raise_cant_connect()
-
-                await asyncio.sleep(0.5)
-
-                _LOGGER.debug("Starting notify")
-                await self._connection.start_notify(
-                    "0000ac02-0000-1000-8000-00805f9b34fb",
-                    lambda sender, message: self.hass.create_task(
-                        self.handle_notify(message)
-                    ),
-                )
-                _LOGGER.debug("Sending initial command")
-                await self._connection.write_gatt_char(
-                    "0000ac01-0000-1000-8000-00805f9b34fb",
-                    bytearray.fromhex("02 04 00 04 00 1a 01 03"),
-                    response=False,
-                )
-            except Exception:
-                _LOGGER.exception("Failed to set up connection, cleaning up")
                 with contextlib.suppress(Exception):
                     await self._connection.disconnect()
+                self._connection = None
+            try:
+                await self._open_connection()
+            except Exception:
+                _LOGGER.exception("Failed to set up connection, cleaning up")
                 self._connection = None  # ensure clean state for next attempt
                 raise
 
@@ -136,6 +142,16 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         else:
             _LOGGER.info("Successfully connected (RSSI not available)")
 
+        # Record when the connection opened (for hold-duration logging).
+        self._connected_at = datetime.now()
+
+        # Back online: cancel any pending unavailable timer and (re)publish
+        # availability to entities.
+        self._cancel_grace()
+        if not self._available:
+            self._available = True
+            self.async_update_listeners()
+
         # If reconnection is configured, set a task to reconnect after interval
         if self._reconnect_interval:
             self.create_reconnect_interval_task()
@@ -143,6 +159,79 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
             _LOGGER.debug("Reconnect after interval task not set")
 
         return True
+
+    async def _open_connection(self) -> None:
+        """Establish a BLE connection and enable notifications.
+
+        Sets ``self._connection`` to the live client on success. Retries the
+        whole establish+subscribe sequence a handful of times because the
+        appliance often drops the link before notifications can be enabled; one
+        of the rapid retries usually lands in a window where it stays up long
+        enough to subscribe. Raises the last error if every attempt fails.
+        """
+        last_error: Exception | None = None
+        for attempt in range(1, _SETUP_MAX_ATTEMPTS + 1):
+            async with self._device_lock:
+                self._device = bluetooth.async_ble_device_from_address(
+                    self._hass, self.address, connectable=True
+                )
+                if not self._device:
+                    raise RuntimeError(f"Device not found for address {self.address}")
+
+                _LOGGER.debug(
+                    "Establishing connection (attempt %d/%d)",
+                    attempt,
+                    _SETUP_MAX_ATTEMPTS,
+                )
+                connection = await establish_connection(
+                    client_class=BleakClient,
+                    device=self._device,
+                    name=self.address,
+                    disconnected_callback=self.disconnected_callback,
+                    # Re-fetch the best device/path on each internal retry
+                    # instead of reusing a stale BLEDevice.
+                    ble_device_callback=lambda: bluetooth.async_ble_device_from_address(
+                        self._hass, self.address, connectable=True
+                    ),
+                )
+
+            try:
+                # Subscribe and send the handshake immediately - any idle time
+                # here invites the appliance to terminate the connection.
+                _LOGGER.debug("Starting notify")
+                await connection.start_notify(
+                    NOTIFY_CHARACTERISTIC,
+                    lambda sender, message: self.hass.create_task(
+                        self.handle_notify(message)
+                    ),
+                )
+                _LOGGER.debug("Sending initial command")
+                await connection.write_gatt_char(
+                    COMMAND_CHARACTERISTIC,
+                    INIT_COMMAND,
+                    response=False,
+                )
+            except Exception as error:  # noqa: BLE001
+                last_error = error
+                _LOGGER.debug(
+                    "Connection setup attempt %d/%d failed: %s",
+                    attempt,
+                    _SETUP_MAX_ATTEMPTS,
+                    error,
+                )
+                with contextlib.suppress(Exception):
+                    await connection.disconnect()
+                if attempt < _SETUP_MAX_ATTEMPTS:
+                    await asyncio.sleep(_SETUP_RETRY_DELAY)
+                continue
+
+            # Publish the live connection before returning so that a drop in the
+            # hand-off window is still routed to handle_disconnect().
+            self._connection = connection
+            return
+
+        assert last_error is not None
+        raise last_error
 
     def create_reconnect_interval_task(self) -> None:
         # Cancel any existing task
@@ -171,6 +260,12 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         if not self.alive:
             _LOGGER.debug("Disconnected callback called but not alive")
             return
+        # Ignore callbacks from intermediate/superseded clients created during
+        # connection setup retries - only the live connection should trigger a
+        # reconnect.
+        if client is not None and client is not self._connection:
+            _LOGGER.debug("Ignoring disconnect from a stale connection")
+            return
         self.hass.create_task(self.handle_disconnect())
 
     @callback
@@ -185,6 +280,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
     async def try_reconnect(self) -> None:
         async with self.reconnecting_lock:
             _LOGGER.debug("[%s] Trying to reconnect", self.address)
+            delay = _RECONNECT_INITIAL_DELAY
             while self.alive and not self.is_connected:
                 if not bluetooth.async_address_present(
                     self.hass, self.address, connectable=True
@@ -193,7 +289,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                         "Device not found. "
                         "Will reconnect automatically when the device becomes available"
                     )
-                    await asyncio.sleep(60)
+                    await asyncio.sleep(_RECONNECT_ABSENT_DELAY)
                     continue  # instead of return
                 try:
                     _LOGGER.debug(
@@ -205,12 +301,17 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                     _LOGGER.debug("Reconnecting was successful!")
                 except Exception:
                     _LOGGER.exception(
-                        "Can't reconnect. Waiting 30 seconds to try again"
+                        "Can't reconnect. Waiting %d seconds to try again", delay
                     )
-                    await asyncio.sleep(30)
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, _RECONNECT_MAX_DELAY)
 
     async def handle_disconnect(self, *args: Any) -> None:
         _LOGGER.debug("Handling disconnect%s...", " by time interval" if args else "")
+        held_for: float | None = None
+        if self._connected_at is not None:
+            held_for = (datetime.now() - self._connected_at).total_seconds()
+            self._connected_at = None
         async with self._connection_lock:
             async with self._device_lock:
                 self._device = None
@@ -219,10 +320,21 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                 _LOGGER.info("Triggering disconnect")
                 with contextlib.suppress(Exception):
                     await self._connection.disconnect()
-            self.hass.add_job(self.async_set_updated_data, None)
             self._connection = None
+        # Don't flap entities unavailable on a brief blip - start the grace
+        # timer and let try_reconnect race it. Entities keep their last state
+        # until the timer fires (only if we're still down by then).
+        if self._available and self._grace_unsub is None:
+            self._grace_unsub = async_call_later(
+                self.hass, _DISCONNECT_GRACE_SECONDS, self._grace_expired
+            )
         # Spawn the task AFTER releasing the lock
-        _LOGGER.info("[%s] Disconnected", self.address)
+        if held_for is not None:
+            _LOGGER.info(
+                "[%s] Disconnected after %.1fs connected", self.address, held_for
+            )
+        else:
+            _LOGGER.info("[%s] Disconnected", self.address)
         self.hass.create_task(self.try_reconnect())
 
     # @callback removed – the function is invoked via create_task, not called directly
@@ -239,30 +351,84 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
             )
             self.async_set_updated_data(full_message)
 
+    async def _await_connection(self, timeout: float) -> None:
+        """Wait up to ``timeout`` seconds for the link to (re)connect.
+
+        Entities stay available across brief supervision-timeout blips, so a
+        command can arrive while a reconnect is in flight. Give the background
+        reconnect a chance to land instead of failing immediately. Raises
+        HomeAssistantError if the device is still not connected by the deadline.
+        """
+        if self.is_connected:
+            return
+        _LOGGER.debug("Command waiting up to %ss for the connection", timeout)
+        try:
+            async with asyncio.timeout(timeout):
+                while not self.is_connected:
+                    await asyncio.sleep(0.25)
+        except TimeoutError as err:
+            raise HomeAssistantError("Device not connected") from err
+
     async def send_command(self, command: Command) -> None:
         _LOGGER.debug("Sending command %s:%s", command.index, command.value)
-        async with self._connection_lock:
-            if self._connection is None or not self._connection.is_connected:
-                _LOGGER.warning("Cannot send command: not connected")
-                raise HomeAssistantError("Device not connected")
-            payload = bytearray([2, 4, 0, 4, 0, command.index, 1, command.value])
-            try:
-                await self._connection.write_gatt_char(
-                    "0000ac01-0000-1000-8000-00805F9B34FB",
-                    payload,
-                )
-            except Exception as e:
-                _LOGGER.error("Failed to send command: %s", e)
-                raise
-            _LOGGER.debug("Command sent")
+        payload = bytearray([2, 4, 0, 4, 0, command.index, 1, command.value])
+        last_error: Exception | None = None
+        for attempt in range(1, _COMMAND_MAX_ATTEMPTS + 1):
+            # Wait (bounded) for a reconnect if we're mid-blip; raises cleanly
+            # if the device is genuinely gone.
+            await self._await_connection(_COMMAND_CONNECT_TIMEOUT)
+            async with self._connection_lock:
+                if self._connection is None or not self._connection.is_connected:
+                    continue  # dropped again before we got the lock; retry
+                try:
+                    await self._connection.write_gatt_char(
+                        COMMAND_CHARACTERISTIC,
+                        payload,
+                    )
+                except Exception as error:  # noqa: BLE001
+                    last_error = error
+                    _LOGGER.warning(
+                        "Command send attempt %d/%d failed: %s",
+                        attempt,
+                        _COMMAND_MAX_ATTEMPTS,
+                        error,
+                    )
+                    continue
+                _LOGGER.debug("Command sent")
+                return
+        raise HomeAssistantError("Failed to send command to device") from last_error
 
     @property
     def is_connected(self) -> bool:
         return self._connection is not None and self._connection.is_connected
 
+    @property
+    def available(self) -> bool:
+        """Debounced availability - True through brief reconnect blips."""
+        return self._available
+
+    def _cancel_grace(self) -> None:
+        if self._grace_unsub is not None:
+            self._grace_unsub()
+            self._grace_unsub = None
+
+    @callback
+    def _grace_expired(self, _now: datetime) -> None:
+        self._grace_unsub = None
+        if not self.is_connected:
+            _LOGGER.info(
+                "[%s] Still disconnected after %ds grace; marking unavailable",
+                self.address,
+                _DISCONNECT_GRACE_SECONDS,
+            )
+            self._available = False
+            self.async_set_updated_data(None)
+
     async def kill(self) -> None:
         _LOGGER.debug("[%s] Killing connection", self.address)
         self.alive = False  # set FIRST, before calling disconnect()
+        self._cancel_grace()
+        self._available = False
         async with self._connection_lock:
             if self._connection is not None:
                 with contextlib.suppress(Exception):

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from bleak import BleakClient, BLEDevice
+from bleak.exc import BleakError
 from bleak_retry_connector import establish_connection
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant, callback
@@ -33,9 +34,13 @@ _SETUP_MAX_ATTEMPTS = 4
 _SETUP_RETRY_DELAY = 1.0
 
 # ESP32 BLE proxies periodically drop the link with a supervision timeout
-# (HCI 0x08) due to WiFi/BLE radio coexistence, even on a strong signal. These
-# blips self-heal in ~1-2s, so don't flap entities unavailable on every drop -
-# only mark unavailable if the connection stays down past this grace period.
+# (HCI 0x08) due to WiFi/BLE radio coexistence, even on a strong signal.
+# Reconnects usually complete within a couple of seconds, but can occasionally
+# take much longer (proxy backhaul hiccups, slow re-advertising, or the reconnect
+# backoff). The grace period is deliberately generous - well above the typical
+# reconnect time - so those slower recoveries don't surface as a spurious
+# "unavailable"; entities only go unavailable once the link has genuinely stayed
+# down this long.
 _DISCONNECT_GRACE_SECONDS = 60
 
 # A control command may arrive during one of those brief blips (entities stay
@@ -225,8 +230,27 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                     await asyncio.sleep(_SETUP_RETRY_DELAY)
                 continue
 
-            # Publish the live connection before returning so that a drop in the
-            # hand-off window is still routed to handle_disconnect().
+            # The link may have dropped during setup; because self._connection
+            # wasn't set yet, disconnected_callback would have ignored it as a
+            # stale client. Verify it's still up before publishing it - there is
+            # no await between this check and the assignment, so the callback
+            # cannot fire in the gap. If it died, retry like any other setup
+            # failure instead of getting stuck believing we're connected.
+            if not connection.is_connected:
+                last_error = BleakError("Link dropped during connection setup")
+                _LOGGER.debug(
+                    "Connection setup attempt %d/%d: link dropped during setup",
+                    attempt,
+                    _SETUP_MAX_ATTEMPTS,
+                )
+                with contextlib.suppress(Exception):
+                    await connection.disconnect()
+                if attempt < _SETUP_MAX_ATTEMPTS:
+                    await asyncio.sleep(_SETUP_RETRY_DELAY)
+                continue
+
+            # Publish the live connection. A drop from here on is recognised by
+            # disconnected_callback (client is self._connection).
             self._connection = connection
             return
 

--- a/custom_components/homewhiz/entity.py
+++ b/custom_components/homewhiz/entity.py
@@ -57,7 +57,7 @@ class HomeWhizEntity(CoordinatorEntity[HomewhizCoordinator]):  # type: ignore[ty
 
     @property
     def available(self) -> bool:  # type: ignore[override]
-        return self.coordinator.is_connected
+        return self.coordinator.available
 
     @property
     def translation_key(self) -> str | None:  # type: ignore[override]

--- a/custom_components/homewhiz/homewhiz.py
+++ b/custom_components/homewhiz/homewhiz.py
@@ -28,6 +28,12 @@ class HomewhizCoordinator(
     def is_connected(self) -> bool:
         pass
 
+    @property
+    def available(self) -> bool:
+        """Whether entities should be available. Defaults to the live
+        connection state; subclasses may debounce it across brief blips."""
+        return self.is_connected
+
     @abc.abstractmethod
     async def send_command(self, command: Command) -> None:
         pass

--- a/custom_components/homewhiz/manifest.json
+++ b/custom_components/homewhiz/manifest.json
@@ -30,5 +30,5 @@
     "aiohttp",
     "bidict"
   ],
-  "version": "v0.5.19"
+  "version": "v0.5.20"
 }

--- a/custom_components/homewhiz/tests/test_bluetooth.py
+++ b/custom_components/homewhiz/tests/test_bluetooth.py
@@ -7,6 +7,7 @@ Home Assistant needed) and mock the BleakClient.
 """
 
 import asyncio
+from datetime import datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -22,12 +23,32 @@ from custom_components.homewhiz.homewhiz import Command
 
 
 class _FakeConnection:
-    """Minimal stand-in for a connected BleakClient."""
+    """Minimal stand-in for a connected BleakClient.
 
-    def __init__(self, *, connected: bool = True, write_side_effect=None) -> None:
-        self.is_connected = connected
+    ``connect_after`` makes ``is_connected`` report disconnected for the first N
+    reads and connected afterwards, so the send_command wait loop can be driven
+    deterministically without real-time sleeps.
+    """
+
+    def __init__(
+        self,
+        *,
+        connected: bool = True,
+        connect_after: int | None = None,
+        write_side_effect=None,
+    ) -> None:
+        self._connected = connected
+        self._connect_after = connect_after
+        self._checks = 0
         self.write_gatt_char = AsyncMock(side_effect=write_side_effect)
         self.disconnect = AsyncMock()
+
+    @property
+    def is_connected(self) -> bool:
+        self._checks += 1
+        if self._connect_after is not None and self._checks > self._connect_after:
+            return True
+        return self._connected
 
 
 def _make_coordinator() -> HomewhizBluetoothUpdateCoordinator:
@@ -83,17 +104,13 @@ async def test_send_command_writes_payload_when_connected() -> None:
 
 async def test_send_command_waits_for_in_flight_reconnect() -> None:
     coord = _make_coordinator()
-    conn = _FakeConnection(connected=False)
+    # Reports disconnected on the first availability check, connected after -
+    # exercises the wait loop without racing on wall-clock time.
+    conn = _FakeConnection(connected=False, connect_after=1)
     coord._connection = conn
 
-    async def _reconnect() -> None:
-        await asyncio.sleep(0.3)
-        conn.is_connected = True
-
-    flipper = asyncio.create_task(_reconnect())
     # Should wait for the reconnect rather than failing immediately.
     await coord.send_command(Command(index=1, value=1))
-    await flipper
 
     conn.write_gatt_char.assert_awaited_once()
 
@@ -144,7 +161,7 @@ def test_grace_expiry_marks_unavailable_when_still_down() -> None:
     coord._available = True
     coord._connection = None  # is_connected -> False
 
-    coord._grace_expired(None)
+    coord._grace_expired(datetime.now())
 
     assert coord.available is False
     coord.async_set_updated_data.assert_called_once_with(None)
@@ -155,7 +172,7 @@ def test_grace_expiry_keeps_available_when_reconnected() -> None:
     coord._available = True
     coord._connection = _FakeConnection(connected=True)
 
-    coord._grace_expired(None)
+    coord._grace_expired(datetime.now())
 
     assert coord.available is True
     coord.async_set_updated_data.assert_not_called()

--- a/custom_components/homewhiz/tests/test_bluetooth.py
+++ b/custom_components/homewhiz/tests/test_bluetooth.py
@@ -1,0 +1,161 @@
+"""Unit tests for the Bluetooth coordinator's resilience logic.
+
+These exercise the connection-blip handling added to fix the flapping reported
+in issue #367: the availability debounce and the send_command wait/retry. They
+build the coordinator without running DataUpdateCoordinator.__init__ (no running
+Home Assistant needed) and mock the BleakClient.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.homewhiz import bluetooth as bt
+from custom_components.homewhiz.bluetooth import (
+    COMMAND_CHARACTERISTIC,
+    HomewhizBluetoothUpdateCoordinator,
+    MessageAccumulator,
+)
+from custom_components.homewhiz.homewhiz import Command
+
+
+class _FakeConnection:
+    """Minimal stand-in for a connected BleakClient."""
+
+    def __init__(self, *, connected: bool = True, write_side_effect=None) -> None:
+        self.is_connected = connected
+        self.write_gatt_char = AsyncMock(side_effect=write_side_effect)
+        self.disconnect = AsyncMock()
+
+
+def _make_coordinator() -> HomewhizBluetoothUpdateCoordinator:
+    """Build a coordinator without running DataUpdateCoordinator.__init__."""
+    coord = object.__new__(HomewhizBluetoothUpdateCoordinator)
+    coord.address = "00:11:22:33:44:55"
+    coord._connection = None
+    coord._connection_lock = asyncio.Lock()
+    coord._available = False
+    coord._grace_unsub = None
+    coord._connected_at = None
+    # Shadow the DataUpdateCoordinator methods so we don't need a real hass.
+    coord.async_set_updated_data = Mock()
+    coord.async_update_listeners = Mock()
+    return coord
+
+
+# --- MessageAccumulator ---
+
+
+def test_accumulator_combines_two_part_message() -> None:
+    acc = MessageAccumulator()
+    assert acc.accumulate_message(bytearray([0, 0, 0, 0, 0, 0, 0, 1, 2, 3])) is None
+    full = acc.accumulate_message(bytearray([0, 0, 0, 0, 1, 0, 0, 4, 5, 6]))
+    assert full == bytearray([1, 2, 3, 4, 5, 6])
+
+
+def test_accumulator_resets_on_unexpected_index() -> None:
+    acc = MessageAccumulator()
+    # index 1 without a preceding index 0 -> reset, returns None
+    assert acc.accumulate_message(bytearray([0, 0, 0, 0, 1, 0, 0, 9])) is None
+    # a fresh 0 then 1 still works afterwards
+    assert acc.accumulate_message(bytearray([0, 0, 0, 0, 0, 0, 0, 7])) is None
+    assert acc.accumulate_message(bytearray([0, 0, 0, 0, 1, 0, 0, 8])) == bytearray(
+        [7, 8]
+    )
+
+
+# --- send_command (wait through reconnect + retry) ---
+
+
+async def test_send_command_writes_payload_when_connected() -> None:
+    coord = _make_coordinator()
+    conn = _FakeConnection(connected=True)
+    coord._connection = conn
+
+    await coord.send_command(Command(index=0x1A, value=3))
+
+    conn.write_gatt_char.assert_awaited_once_with(
+        COMMAND_CHARACTERISTIC, bytearray([2, 4, 0, 4, 0, 0x1A, 1, 3])
+    )
+
+
+async def test_send_command_waits_for_in_flight_reconnect() -> None:
+    coord = _make_coordinator()
+    conn = _FakeConnection(connected=False)
+    coord._connection = conn
+
+    async def _reconnect() -> None:
+        await asyncio.sleep(0.3)
+        conn.is_connected = True
+
+    flipper = asyncio.create_task(_reconnect())
+    # Should wait for the reconnect rather than failing immediately.
+    await coord.send_command(Command(index=1, value=1))
+    await flipper
+
+    conn.write_gatt_char.assert_awaited_once()
+
+
+async def test_send_command_times_out_when_device_gone(monkeypatch) -> None:
+    monkeypatch.setattr(bt, "_COMMAND_CONNECT_TIMEOUT", 0.4)
+    coord = _make_coordinator()
+    coord._connection = _FakeConnection(connected=False)
+
+    with pytest.raises(HomeAssistantError):
+        await coord.send_command(Command(index=1, value=1))
+
+
+async def test_send_command_retries_after_transient_write_failure() -> None:
+    coord = _make_coordinator()
+    conn = _FakeConnection(connected=True, write_side_effect=[Exception("boom"), None])
+    coord._connection = conn
+
+    await coord.send_command(Command(index=1, value=1))
+
+    assert conn.write_gatt_char.await_count == 2
+
+
+async def test_send_command_raises_after_exhausting_attempts(monkeypatch) -> None:
+    monkeypatch.setattr(bt, "_COMMAND_MAX_ATTEMPTS", 2)
+    coord = _make_coordinator()
+    conn = _FakeConnection(connected=True, write_side_effect=Exception("boom"))
+    coord._connection = conn
+
+    with pytest.raises(HomeAssistantError):
+        await coord.send_command(Command(index=1, value=1))
+    assert conn.write_gatt_char.await_count == 2
+
+
+# --- availability debounce ---
+
+
+def test_available_reflects_internal_flag() -> None:
+    coord = _make_coordinator()
+    coord._available = False
+    assert coord.available is False
+    coord._available = True
+    assert coord.available is True
+
+
+def test_grace_expiry_marks_unavailable_when_still_down() -> None:
+    coord = _make_coordinator()
+    coord._available = True
+    coord._connection = None  # is_connected -> False
+
+    coord._grace_expired(None)
+
+    assert coord.available is False
+    coord.async_set_updated_data.assert_called_once_with(None)
+
+
+def test_grace_expiry_keeps_available_when_reconnected() -> None:
+    coord = _make_coordinator()
+    coord._available = True
+    coord._connection = _FakeConnection(connected=True)
+
+    coord._grace_expired(None)
+
+    assert coord.available is True
+    coord.async_set_updated_data.assert_not_called()

--- a/docs/connection-test.md
+++ b/docs/connection-test.md
@@ -1,0 +1,152 @@
+# Bluetooth control / connection test
+
+A small, self-contained Home Assistant test you can run on your own appliance to
+check that **commands survive the periodic BLE reconnects** and that entities
+**stay available** through them (the behaviour fixed for issue #367).
+
+It repeatedly toggles a setting, waits for the appliance to reflect the change
+back, and tallies pass/fail. Because it runs for a few minutes, some commands
+land *during* a connection drop — which is exactly what we want to exercise.
+
+## What you need to change for your appliance
+
+The example targets a washing machine whose entities are prefixed
+`*_washing_machine_*`. Replace these with your appliance's:
+
+| Placeholder | What to use |
+|---|---|
+| `select.washing_machine_button_volume` | A **programme-independent** select on your appliance (button/key volume is ideal — the selected programme can't clamp it). Pick something with two stable options. |
+| `volume_high` / `volume_low` | The two option values of that select (see the entity's `options` attribute in Developer Tools → States). |
+| `binary_sensor.washing_machine_remote_control` | Your appliance's remote-control indicator. |
+
+> Avoid using temperature/spin/rinse for the stress target: many programmes
+> **clamp** those values (e.g. a delicates programme forces a lower temperature),
+> so the read-back check fails even though the command was delivered — a false
+> negative. A device setting like key volume can't be clamped.
+
+## Before running
+
+1. Put the appliance into **Remote Control** mode.
+2. If you test a programme-dependent setting, also select a programme — but do
+   **not** press Start. (On Beko machines, turning the dial exits remote mode;
+   set the programme from HA via its `select.*_programme` entity instead.)
+
+## Helpers (counters for the tally)
+
+```yaml
+# configuration.yaml
+counter:
+  homewhiz_test_pass:
+    name: HomeWhiz Test Pass
+    initial: 0
+    step: 1
+  homewhiz_test_fail:
+    name: HomeWhiz Test Fail
+    initial: 0
+    step: 1
+```
+
+## Script
+
+```yaml
+# scripts.yaml  (or Settings → Automations & Scenes → Scripts → ⋮ → Edit in YAML)
+homewhiz_volume_stress:
+  alias: HomeWhiz volume stress test
+  icon: mdi:volume-high
+  mode: restart
+  fields:
+    cycles:
+      name: Cycles
+      default: 16
+      selector:
+        number:
+          min: 1
+          max: 100
+          mode: box
+  sequence:
+    - action: counter.reset
+      target:
+        entity_id:
+          - counter.homewhiz_test_pass
+          - counter.homewhiz_test_fail
+    - action: persistent_notification.create
+      data:
+        notification_id: homewhiz_test
+        title: HomeWhiz volume stress
+        message: >-
+          Toggling button volume {{ cycles }} cycles over ~3 min, across BLE
+          drops. Watch the entity stay available and listen for beeps.
+    - repeat:
+        count: "{{ cycles }}"
+        sequence:
+          - action: select.select_option
+            continue_on_error: true
+            target:
+              entity_id: select.washing_machine_button_volume
+            data:
+              option: volume_high
+          - wait_template: >-
+              {{ is_state('select.washing_machine_button_volume', 'volume_high') }}
+            timeout: { seconds: 15 }
+            continue_on_timeout: true
+          - if:
+              - condition: template
+                value_template: "{{ wait.completed }}"
+            then:
+              - action: counter.increment
+                target: { entity_id: counter.homewhiz_test_pass }
+            else:
+              - action: counter.increment
+                target: { entity_id: counter.homewhiz_test_fail }
+              - action: logbook.log
+                data:
+                  name: HomeWhiz test
+                  message: "FAIL cycle {{ repeat.index }}: volume_high not applied within 15s"
+          - action: select.select_option
+            continue_on_error: true
+            target:
+              entity_id: select.washing_machine_button_volume
+            data:
+              option: volume_low
+          - wait_template: >-
+              {{ is_state('select.washing_machine_button_volume', 'volume_low') }}
+            timeout: { seconds: 15 }
+            continue_on_timeout: true
+          - if:
+              - condition: template
+                value_template: "{{ wait.completed }}"
+            then:
+              - action: counter.increment
+                target: { entity_id: counter.homewhiz_test_pass }
+            else:
+              - action: counter.increment
+                target: { entity_id: counter.homewhiz_test_fail }
+              - action: logbook.log
+                data:
+                  name: HomeWhiz test
+                  message: "FAIL cycle {{ repeat.index }}: volume_low not applied within 15s"
+          - delay: { seconds: 4 }
+    - action: persistent_notification.create
+      data:
+        notification_id: homewhiz_test
+        title: HomeWhiz volume stress - done
+        message: >-
+          PASS: {{ states('counter.homewhiz_test_pass') }}   FAIL: {{
+          states('counter.homewhiz_test_fail') }}. Any FAIL = a command that did
+          not reach the appliance within 15s.
+```
+
+## Running and reading the result
+
+1. Reload scripts (or restart HA) so the script/counters exist.
+2. Run **`script.homewhiz_volume_stress`** (Settings → Scripts → Run).
+3. When it finishes, the notification shows `PASS` / `FAIL`. Details for each
+   failure are in **Settings → Logbook** (filter `HomeWhiz test`).
+
+**Interpreting it:**
+
+- **All / almost-all PASS** across the run = control is surviving the BLE drops.
+- While it runs, confirm the entity **never shows `unavailable`** (check its
+  history) — that's the availability debounce holding through the drops.
+- A rare FAIL can happen if a command lands during an unusually long reconnect;
+  a cluster of FAILs means commands are genuinely not getting through.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.ruff]
 target-version = "py313"
 [tool.ruff.lint]
@@ -163,3 +166,7 @@ ignore = [
   # Temporarily disabled
   "TRY002",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests legitimately reach into coordinator internals to exercise blip handling.
+"custom_components/homewhiz/tests/*" = ["SLF001"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-asyncio
 serial
 pyserial
 bluetooth_auto_recovery


### PR DESCRIPTION
Fixes the persistent Bluetooth connect/disconnect flapping reported in #367 for appliances bridged through an ESPHome Bluetooth proxy.

## Root cause
ESP-side debug logs show every steady-state drop is an HCI `0x08` **connection supervision timeout**, occurring every ~30–180 s even at strong RSSI. It comes from the ESP32's WiFi/BLE **radio coexistence** (one shared radio) — a hardware-level limit the integration can't prevent, only recover from gracefully. Ruled out by experiment: distance, antenna placement, idle reaping, appliance-initiated termination, and scan duty cycle.

The old flow amplified each drop: tear down → flat 30 s wait → and flip every entity `unavailable`, so an idle appliance flapped continuously and any control command issued during a blip failed outright.

## Changes (all in the Bluetooth coordinator)
- **connect**: drop the fixed `0.5 s` idle sleep (it sat exactly in the window where the appliance terminates the link), retry establish+subscribe in place, and pass `ble_device_callback` so retries re-select the best path.
- **reconnect**: short capped-exponential backoff (3 s → 60 s) instead of a flat 30 s, so the (often single) proxy slot is re-grabbed before the advertisement goes stale.
- **disconnect**: ignore callbacks from superseded/intermediate clients and drop a lingering stale client, so a proxy connection slot is never leaked.
- **availability debounce**: entities stay available across brief (~1–2 s) reconnects and only go `unavailable` after a grace period — a self-healing blip no longer flaps the logbook.
- **send_command**: wait for an in-flight reconnect and retry the write rather than failing immediately, so control survives a drop.
- Log how long each connection was held before dropping; hoist GATT UUIDs / the init command into constants (fixes a case-mismatched duplicate).

## Tests
- `tests/test_bluetooth.py` covers `send_command` (wait-for-reconnect / retry / timeout), the availability debounce, and `MessageAccumulator`. The coordinator is built without `DataUpdateCoordinator.__init__` and the `BleakClient` is mocked, so no running HA instance is required. Adds `pytest-asyncio` (`asyncio_mode=auto`).

## Validated on hardware
A Beko washer via a single ESPHome proxy:
- **Availability debounce:** 0 entity `unavailable` transitions across 15+ BLE drops (previously every drop = a flap).
- **Control resilience:** 31/32 commands delivered and reflected back by the appliance across 3 live drops during the test.

`docs/connection-test.md` includes a self-contained HA script others can adapt to reproduce the control test on their own appliance.

> Note: this does not stop the underlying `0x08` drops (an ESP32 radio limitation) — it makes the integration ride through them seamlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)