### PR TITLE
Retry cloud login on transient network/DNS failure

### DIFF
--- a/custom_components/homewhiz/cloud.py
+++ b/custom_components/homewhiz/cloud.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+import aiohttp
 from dacite import from_dict
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -86,9 +87,24 @@ class HomewhizCloudUpdateCoordinator(HomewhizCoordinator):
         )
 
         _LOGGER.info("Connecting to %s", self._appliance_id)
-        credentials = await login(
-            self._cloud_config.username, self._cloud_config.password
-        )
+        try:
+            credentials = await login(
+                self._cloud_config.username, self._cloud_config.password
+            )
+        except (TimeoutError, aiohttp.ClientError):
+            # Transient login failure (e.g. HA boots before DNS is ready after an
+            # outage): schedule a retry like the AwsCrtError path, don't die.
+            _LOGGER.exception(
+                "Login to the cloud failed (transient). Will retry in one minute."
+            )
+            self._entry.async_on_unload(
+                async_track_point_in_time(
+                    hass=self.hass,
+                    action=self.refresh_connection,  # type: ignore[arg-type]
+                    point_in_time=datetime.today() + timedelta(minutes=1),
+                )
+            )
+            return False
 
         expiration = datetime.fromtimestamp(credentials.expiration / 1000, tz=UTC)
         _LOGGER.debug("Credentials expire at: %s", expiration)


### PR DESCRIPTION
A transient `login()` failure at boot escapes the fire-and-forget connect task, so the cloud device stays `unavailable` until a manual reload. Seen live after a power outage and reproduced locally.