### PR TITLE
Update release workflow to use gh CLI for uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Create homewhiz.zip
       run: cd custom_components && zip -r ../homewhiz.zip homewhiz/
     - name: Upload homewhiz.zip to release
-      uses: softprops/action-gh-release@v3
-      with:
-        files: homewhiz.zip
+      env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "$RELEASE_TAG" homewhiz.zip      


### PR DESCRIPTION
See https://github.com/jwillemsen/daikin_onecta/blob/master/.github/workflows/release.yml for my version which works now