### PR TITLE
Add writable number for the washer start delay

### DIFF
--- a/custom_components/homewhiz/appliance_controls.py
+++ b/custom_components/homewhiz/appliance_controls.py
@@ -228,6 +228,35 @@ class TimeControl(Control):
         return hours * 60 + minutes
 
 
+class WriteTimeControl(Control):
+    """Writable counterpart of :class:`TimeControl` for a delay/timer value.
+
+    Reads the same hour/minute byte indices as ``TimeControl`` (value expressed in
+    minutes), but adds :meth:`set_value` so the value can be written back to the
+    appliance. It is a standalone ``Control`` subclass (not a ``TimeControl``) so it
+    is surfaced as a writable ``number`` entity instead of a read-only ``sensor``.
+    """
+
+    def __init__(self, key: str, hour_index: int, minute_index: int | None):
+        self.key = key
+        self.hour_index = hour_index
+        self.minute_index = minute_index
+
+    def get_value(self, data: bytearray) -> int:
+        hours = safe_get(data, self.hour_index)
+        minutes = (
+            safe_get(data, self.minute_index) if self.minute_index is not None else 0
+        )
+        return hours * 60 + minutes
+
+    def set_value(self, minutes: int) -> list[Command]:
+        minutes = max(0, int(minutes))
+        commands = [Command(self.hour_index, minutes // 60)]
+        if self.minute_index is not None:
+            commands.append(Command(self.minute_index, minutes % 60))
+        return commands
+
+
 class StateAwareRemainingTimeControl(Control):
     """Wraps a remaining time control to return 0 when device is off."""
 
@@ -757,6 +786,17 @@ def build_controls_from_progress_variables(  # noqa: C901
                 feature_key = "delay_start#" + str(len(delay_keys))
                 delay_keys.update(
                     {calculation_key: (feature_key, feature.isCalculatedToStart)}
+                )
+                # Expose the start delay as a writable number (in addition to the
+                # read-only sensor), reusing the same hour/minute byte indices.
+                results.append(
+                    WriteTimeControl(
+                        key=feature_key.replace("delay_start", "delay_start_set", 1),
+                        hour_index=feature.hour.wifiArrayIndex,
+                        minute_index=feature.minute.wifiArrayIndex
+                        if feature.minute is not None
+                        else None,
+                    )
                 )
             results.append(
                 TimeControl(

--- a/custom_components/homewhiz/const.py
+++ b/custom_components/homewhiz/const.py
@@ -5,6 +5,7 @@ DOMAIN = "homewhiz"
 PLATFORMS = [
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.NUMBER,
     Platform.CLIMATE,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,

--- a/custom_components/homewhiz/icons.json
+++ b/custom_components/homewhiz/icons.json
@@ -18,6 +18,11 @@
           }
         }
       }
+    },
+    "number": {
+      "delay_start_set": {
+        "default": "mdi:timer-edit-outline"
+      }
     }
   }
 }

--- a/custom_components/homewhiz/number.py
+++ b/custom_components/homewhiz/number.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .appliance_controls import WriteTimeControl, generate_controls_from_config
+from .config_flow import EntryData
+from .const import DOMAIN
+from .entity import HomeWhizEntity
+from .helper import build_entry_data
+from .homewhiz import HomewhizCoordinator
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+# The appliance stores the delay in one byte for hours and one for minutes, so the
+# largest value it can represent is 23h59m. Expressed in minutes for a single unit.
+MAX_DELAY_MINUTES = 23 * 60 + 59
+
+
+class HomeWhizNumberEntity(HomeWhizEntity, NumberEntity):
+    _attr_native_min_value = 0
+    _attr_native_max_value = MAX_DELAY_MINUTES
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self,
+        coordinator: HomewhizCoordinator,
+        control: WriteTimeControl,
+        device_name: str,
+        data: EntryData,
+    ):
+        super().__init__(coordinator, device_name, control.key, data)
+        self._control = control
+        # Override the per-entity translation device_class set by HomeWhizEntity with
+        # the standard duration device class.
+        self._attr_device_class = NumberDeviceClass.DURATION
+
+    @property
+    def native_value(self) -> float | None:  # type: ignore[override]
+        if self.coordinator.data is None:
+            return None
+        return self._control.get_value(self.coordinator.data)
+
+    async def async_set_native_value(self, value: float) -> None:
+        for command in self._control.set_value(int(value)):
+            await self.coordinator.send_command(command)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    data = build_entry_data(entry)
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    controls = generate_controls_from_config(entry.entry_id, data.contents.config)
+    number_controls = [c for c in controls if isinstance(c, WriteTimeControl)]
+    _LOGGER.debug("Numbers: %s", [c.key for c in number_controls])
+    async_add_entities(
+        [
+            HomeWhizNumberEntity(coordinator, control, entry.title, data)
+            for control in number_controls
+        ]
+    )

--- a/custom_components/homewhiz/tests/test_controls.py
+++ b/custom_components/homewhiz/tests/test_controls.py
@@ -8,8 +8,10 @@ from dacite import from_dict
 from custom_components.homewhiz.appliance_config import ApplianceConfiguration
 from custom_components.homewhiz.appliance_controls import (
     EnumControl,
+    WriteTimeControl,
     generate_controls_from_config,
 )
+from custom_components.homewhiz.homewhiz import Command
 
 test_case = TestCase()
 test_case.maxDiff = None
@@ -42,3 +44,32 @@ def test_options_order(config: ApplianceConfiguration) -> None:
             "90c",
         ],
     )
+
+
+def test_writable_start_delay(config: ApplianceConfiguration) -> None:
+    controls = generate_controls_from_config("test_writable_start_delay", config)
+    controls_map = {control.key: control for control in controls}
+
+    # Writable counterpart of the read-only "delay_start#0" sensor.
+    assert "delay_start_set#0" in controls_map
+    delay = controls_map["delay_start_set#0"]
+    assert isinstance(delay, WriteTimeControl)
+    assert delay.minute_index is not None
+
+    # 125 minutes -> 2h 5m, written to the hour and minute bytes.
+    assert delay.set_value(125) == [
+        Command(delay.hour_index, 2),
+        Command(delay.minute_index, 5),
+    ]
+
+    # Negative values are clamped to zero.
+    assert delay.set_value(-10) == [
+        Command(delay.hour_index, 0),
+        Command(delay.minute_index, 0),
+    ]
+
+    # Written commands round-trip through get_value.
+    data = bytearray(max(delay.hour_index, delay.minute_index) + 1)
+    for command in delay.set_value(125):
+        data[command.index] = command.value
+    assert delay.get_value(data) == 125

--- a/custom_components/homewhiz/tests/test_washing_machine.py
+++ b/custom_components/homewhiz/tests/test_washing_machine.py
@@ -63,6 +63,7 @@ def test_on(config: ApplianceConfiguration) -> None:
             "washer_add_water": False,
             "custom_duration_level": "duration_level_0",
             "delay_start#0": 0,
+            "delay_start_set#0": 0,
             "delay_start_time#0": None,
         },
     )
@@ -109,6 +110,7 @@ def test_running(config: ApplianceConfiguration) -> None:
             "washer_add_water": False,
             "custom_duration_level": "duration_level_0",
             "delay_start#0": 0,
+            "delay_start_set#0": 0,
             "delay_start_time#0": None,
         },
     )
@@ -155,6 +157,7 @@ def test_spinning(config: ApplianceConfiguration) -> None:
             "washer_add_water": False,
             "custom_duration_level": "duration_level_0",
             "delay_start#0": 0,
+            "delay_start_set#0": 0,
             "delay_start_time#0": None,
         },
     )
@@ -201,6 +204,7 @@ def test_delay_defined(config: ApplianceConfiguration) -> None:
             "washer_add_water": False,
             "custom_duration_level": "duration_level_0",
             "delay_start#0": 104,
+            "delay_start_set#0": 104,
             "delay_start_time#0": datetime.datetime.now(tz=datetime.UTC).replace(
                 second=0, microsecond=0
             )
@@ -253,6 +257,7 @@ def test_warning(config: ApplianceConfiguration) -> None:
             "washer_add_water": True,
             "custom_duration_level": "duration_level_0",
             "delay_start#0": 0,
+            "delay_start_set#0": 0,
             "delay_start_time#0": None,
         },
     )
@@ -303,6 +308,7 @@ def test_remote_control_custom_settings(config: ApplianceConfiguration) -> None:
             "washer_add_water": True,
             "custom_duration_level": "duration_level_0",
             "delay_start#0": 0,
+            "delay_start_set#0": 0,
             "delay_start_time#0": None,
         },
     )

--- a/custom_components/homewhiz/tests/test_washing_machine_with_dryer.py
+++ b/custom_components/homewhiz/tests/test_washing_machine_with_dryer.py
@@ -64,6 +64,7 @@ def test_off(config: ApplianceConfiguration) -> None:
             "washer_add_water": False,
             "custom_duration_level": "duration_level_0",
             "delay_start#0": 0,
+            "delay_start_set#0": 0,
             "delay_start_time#0": None,
         },
     )

--- a/custom_components/homewhiz/translations/en.json
+++ b/custom_components/homewhiz/translations/en.json
@@ -990,6 +990,11 @@
         "name": "Auto turn on"
       }
     },
+    "number": {
+      "delay_start_set": {
+        "name": "Start Delay"
+      }
+    },
     "binary_sensor": {
       "remote_control": {
         "name": "Remote control"


### PR DESCRIPTION
The washer start delay is currently exposed read-only through the `delay_start` sensor. This adds a writable `number` entity so the delay can be set from Home Assistant (e.g. to start a wash at a cheaper electricity tariff), which previously was only possible from the HomeWhiz app.

I am currently running this patch on my Yellow for a while now, and it works like a charm.

Please let me know if you'd like me to change anything, or feel free to change it yourself of course.

## What

Adds a **writable `number` entity for the washer start delay**, so the delay can be set from Home Assistant instead of only from the HomeWhiz app.

Today the start delay is exposed **read-only** through the `delay_start` sensor; you can see the configured delay but not change it. This makes it possible to e.g. start a wash at a cheaper electricity tariff straight from HA.

## How

- **`WriteTimeControl`** (`appliance_controls.py`): a `Control` that reads the same hour/minute bytes as `TimeControl` (value in minutes) and adds `set_value()`, which clamps to `>= 0` and emits the hour/minute write `Command`s. It is a standalone `Control` subclass (not a `TimeControl`) so it is surfaced as a writable `number` rather than a read-only `sensor`.
- `build_controls_from_progress_variables` emits it for the `washer_delay` feature (the `isCalculatedToStart` delay) as `delay_start_set#N`, **alongside** the existing read-only `delay_start#N` `TimeControl`. The distinct key keeps it out of the existing `delay_*_time` timestamp calculations, so **nothing changes for current users** (the read-only sensor is unaffected).
- New **`number` platform** exposing `WriteTimeControl` as a `NumberDeviceClass.DURATION` number (unit minutes, box input, `0–23h59m`). Name/icon come from `translations/en.json` + `icons.json` via the existing `translation_key` mechanism — no hardcoded strings.

## Testing

- `test_writable_start_delay` covers `set_value`/`get_value` (incl. clamping and a round-trip). Existing washer test expectations updated for the added control.
- Full suite green locally: `pytest` 43 passed, `ruff check` + `ruff format` clean, `mypy` clean on the changed files, `codespell` + `pretty-format-json` clean.
- Tested on a real Beko washer: setting the value updates the appliance's start delay (confirmed via the read-only `start_delay` sensor) and the program then starts at the configured time.

## Notes / open question

- This is intentionally **additive and non-breaking**: a washer now has both `sensor.<device>_start_delay` (read-only) and `number.<device>_start_delay` (read/write). If you'd prefer to drop the now-redundant sensor in favour of the number, happy to adjust.
- Scope is the `washer_delay` start delay only; other delay representations (`dishwasher_delay`, etc.) are untouched.
- `manifest.json` version intentionally not bumped — left to maintainers for release.