### PR TITLE
Avoid bidict duplication error for program options

### DIFF
--- a/custom_components/homewhiz/appliance_controls.py
+++ b/custom_components/homewhiz/appliance_controls.py
@@ -651,9 +651,13 @@ def get_options_from_feature(key: str, feature: ApplianceFeature) -> bidict[int,
 def get_options_from_enum_options(
     options: Sequence[ApplianceFeatureEnumOption],
 ) -> dict[int, str]:
-    return {
-        option.wifiArrayValue: to_friendly_name(option.strKey) for option in options
-    }
+    result: dict[int, str] = {}
+    for option in options:
+        friendly_name = to_friendly_name(option.strKey)
+        if friendly_name in result.values():
+            friendly_name = f"{friendly_name}_{option.wifiArrayValue}"
+        result[option.wifiArrayValue] = friendly_name
+    return result
 
 
 def build_read_control_from_feature(feature: ApplianceFeature) -> Control | None:

--- a/custom_components/homewhiz/tests/fixtures/beko-washer-410.json
+++ b/custom_components/homewhiz/tests/fixtures/beko-washer-410.json
@@ -1,0 +1,2176 @@
+{
+  "program": {
+    "strKey": "WASHER_PROGRAM",
+    "isSwitch": null,
+    "values": [
+      {
+        "strKey": "PROGRAM_COTTONS",
+        "wifiArrayValue": 1,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ],
+            "isDisabled": null,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_COTTONS_ECO",
+        "wifiArrayValue": 2,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_SYNTHETICS",
+        "wifiArrayValue": 3,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11
+            ],
+            "isDisabled": null,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_MINI_MINI14",
+        "wifiArrayValue": 4,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_WOOL_HANDWASH",
+        "wifiArrayValue": 5,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_SHIRTS",
+        "wifiArrayValue": 6,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_MIX",
+        "wifiArrayValue": 7,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_SPIN_PUMP",
+        "wifiArrayValue": 8,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_RINSING",
+        "wifiArrayValue": 9,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_DARKWASH_JEANS",
+        "wifiArrayValue": 10,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_DUVET_DOWNWEAR",
+        "wifiArrayValue": 11,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_STAIN",
+        "wifiArrayValue": 12,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_HYGIENE_PLUS",
+        "wifiArrayValue": 13,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              1,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              2,
+              3,
+              4,
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_OUTDOOR_SPORTS_GORETEX",
+        "wifiArrayValue": 14,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_STEAM_THERAPY",
+        "wifiArrayValue": 15,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_MIX",
+        "wifiArrayValue": 16,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_DELICATES",
+        "wifiArrayValue": 17,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_LINGERIE",
+        "wifiArrayValue": 18,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              2
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_SOFT_TOYS",
+        "wifiArrayValue": 19,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_STEAM"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_TOWEL",
+        "wifiArrayValue": 20,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3,
+              4
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              1,
+              2,
+              3
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          }
+        ],
+        "isVisible": 1
+      },
+      {
+        "strKey": "PROGRAM_DRUM_CLEAN",
+        "wifiArrayValue": 29,
+        "customSubProgramOverrides": [
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "CUSTOM_DURATION_LEVEL"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRA_RINSE_COUNT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ANTICREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_SOAKING"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_ADD_WATER"
+          }
+        ],
+        "isDownloadableCycle": null,
+        "progressVariableOverrides": null,
+        "subProgramOverrides": [
+          {
+            "allowedValueIndices": [
+              5
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_TEMPERATURE"
+          },
+          {
+            "allowedValueIndices": [
+              0,
+              2
+            ],
+            "isDisabled": null,
+            "strKeyRef": "WASHER_SPIN"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_NIGHT"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST_PLUS"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_FAST"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_HIDDEN_ANTI_CREASE"
+          },
+          {
+            "allowedValueIndices": null,
+            "isDisabled": 1,
+            "strKeyRef": "WASHER_EXTRARINSE"
+          }
+        ],
+        "isVisible": 1
+      }
+    ],
+    "wifiArrayIndex": 36,
+    "wfaWriteIndex": null,
+    "isVisible": 1
+  },
+  "subPrograms": [
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "TEMPERATURE_COLD_WASH",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "TEMPERATURE_20",
+          "wifiArrayValue": 20
+        },
+        {
+          "strKey": "TEMPERATURE_30",
+          "wifiArrayValue": 30
+        },
+        {
+          "strKey": "TEMPERATURE_40",
+          "wifiArrayValue": 40
+        },
+        {
+          "strKey": "TEMPERATURE_60",
+          "wifiArrayValue": 60
+        },
+        {
+          "strKey": "TEMPERATURE_90",
+          "wifiArrayValue": 90
+        }
+      ],
+      "isSwitch": null,
+      "strKey": "WASHER_TEMPERATURE",
+      "wifiArrayIndex": 37,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "SPIN_NO_SPIN",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "SPIN_RINSE_HOLD",
+          "wifiArrayValue": 17
+        },
+        {
+          "strKey": "SPIN_600",
+          "wifiArrayValue": 6
+        },
+        {
+          "strKey": "SPIN_800",
+          "wifiArrayValue": 8
+        },
+        {
+          "strKey": "SPIN_1200",
+          "wifiArrayValue": 12
+        },
+        {
+          "strKey": "SPIN_1400",
+          "wifiArrayValue": 14
+        }
+      ],
+      "isSwitch": null,
+      "strKey": "WASHER_SPIN",
+      "wifiArrayIndex": 38,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "EXTRA_RINSE_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "EXTRA_RINSE_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_EXTRARINSE",
+      "wifiArrayIndex": 41,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "STEAM_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "STEAM_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_STEAM",
+      "wifiArrayIndex": 61,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "FAST_PLUS_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "FAST_PLUS_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_FAST_PLUS",
+      "wifiArrayIndex": 69,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "FAST_OFF",
+          "wifiArrayValue": 1
+        },
+        {
+          "strKey": "FAST_ON",
+          "wifiArrayValue": 0
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_FAST",
+      "wifiArrayIndex": 43,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "HIDDEN_ANTI_CREASE_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "HIDDEN_ANTI_CREASE_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_HIDDEN_ANTI_CREASE",
+      "wifiArrayIndex": 66,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "NIGHT_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "NIGHT_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_NIGHT",
+      "wifiArrayIndex": 42,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    }
+  ],
+  "progressVariables": {
+    "autoOff": null,
+    "autoOn": null,
+    "delay": {
+      "hour": {
+        "boundedValues": [
+          {
+            "factor": 1,
+            "lowerLimit": 0,
+            "step": 1,
+            "strKey": "HOUR",
+            "unit": "",
+            "upperLimit": 23
+          }
+        ],
+        "enumValues": null,
+        "isSwitch": null,
+        "strKey": null,
+        "wifiArrayIndex": 48,
+        "wfaWriteIndex": null,
+        "isVisible": 1
+      },
+      "isExpandableBySwitch": null,
+      "minute": {
+        "boundedValues": [
+          {
+            "factor": 1,
+            "lowerLimit": 0,
+            "step": 1,
+            "strKey": "MINUTE",
+            "unit": "",
+            "upperLimit": 59
+          }
+        ],
+        "enumValues": null,
+        "isSwitch": null,
+        "strKey": null,
+        "wifiArrayIndex": 49,
+        "wfaWriteIndex": null,
+        "isVisible": 1
+      },
+      "strKey": "WASHER_DELAY",
+      "wfaIndex": null,
+      "wfaWriteIndex": null,
+      "isCalculatedToStart": 0,
+      "isVisible": 1
+    },
+    "duration": {
+      "hour": {
+        "boundedValues": [
+          {
+            "factor": 1,
+            "lowerLimit": 0,
+            "step": 1,
+            "strKey": "HOUR",
+            "unit": "",
+            "upperLimit": 23
+          }
+        ],
+        "enumValues": null,
+        "isSwitch": null,
+        "strKey": null,
+        "wifiArrayIndex": 44,
+        "wfaWriteIndex": null,
+        "isVisible": 1
+      },
+      "isExpandableBySwitch": null,
+      "minute": {
+        "boundedValues": [
+          {
+            "factor": 1,
+            "lowerLimit": 0,
+            "step": 1,
+            "strKey": "MINUTE",
+            "unit": "",
+            "upperLimit": 59
+          }
+        ],
+        "enumValues": null,
+        "isSwitch": null,
+        "strKey": null,
+        "wifiArrayIndex": 45,
+        "wfaWriteIndex": null,
+        "isVisible": 1
+      },
+      "strKey": "WASHER_DURATION",
+      "wfaIndex": null,
+      "wfaWriteIndex": null,
+      "isCalculatedToStart": null,
+      "isVisible": 0
+    },
+    "elapsed": null,
+    "fermentedremaining": null,
+    "remaining": {
+      "hour": {
+        "boundedValues": [
+          {
+            "factor": 1,
+            "lowerLimit": 0,
+            "step": 1,
+            "strKey": "HOUR",
+            "unit": "",
+            "upperLimit": 23
+          }
+        ],
+        "enumValues": null,
+        "isSwitch": null,
+        "strKey": null,
+        "wifiArrayIndex": 46,
+        "wfaWriteIndex": null,
+        "isVisible": 1
+      },
+      "isExpandableBySwitch": null,
+      "minute": {
+        "boundedValues": [
+          {
+            "factor": 1,
+            "lowerLimit": 0,
+            "step": 1,
+            "strKey": "MINUTE",
+            "unit": "",
+            "upperLimit": 59
+          }
+        ],
+        "enumValues": null,
+        "isSwitch": null,
+        "strKey": null,
+        "wifiArrayIndex": 47,
+        "wfaWriteIndex": null,
+        "isVisible": 1
+      },
+      "strKey": "WASHER_REMAINING",
+      "wfaIndex": null,
+      "wfaWriteIndex": null,
+      "isCalculatedToStart": null,
+      "isVisible": 0
+    },
+    "remainingOrElapsed": null
+  },
+  "deviceStates": {
+    "states": [
+      {
+        "strKey": "DEVICE_STATE_ON",
+        "wifiArrayValue": 10,
+        "notificationInfo": {
+          "necessity": null,
+          "priority": "MEDIUM",
+          "strKey": "DEVICE_STATE_ON_NOTIFICATION"
+        },
+        "allowedTransitions": [
+          "DEVICE_STATE_OFF",
+          "DEVICE_STATE_RUNNING"
+        ]
+      },
+      {
+        "strKey": "DEVICE_STATE_OFF",
+        "wifiArrayValue": 20,
+        "notificationInfo": {
+          "necessity": null,
+          "priority": "MEDIUM",
+          "strKey": "DEVICE_STATE_OFF_NOTIFICATION"
+        },
+        "allowedTransitions": [
+          "DEVICE_STATE_ON"
+        ]
+      },
+      {
+        "strKey": "DEVICE_STATE_RUNNING",
+        "wifiArrayValue": 30,
+        "notificationInfo": {
+          "necessity": null,
+          "priority": "MEDIUM",
+          "strKey": "DEVICE_STATE_RUNNING_NOTIFICATION"
+        },
+        "allowedTransitions": [
+          "DEVICE_STATE_OFF",
+          "DEVICE_STATE_PAUSED"
+        ]
+      },
+      {
+        "strKey": "DEVICE_STATE_PAUSED",
+        "wifiArrayValue": 40,
+        "notificationInfo": {
+          "necessity": null,
+          "priority": "MEDIUM",
+          "strKey": "DEVICE_STATE_PAUSED_NOTIFICATION"
+        },
+        "allowedTransitions": [
+          "DEVICE_STATE_OFF",
+          "DEVICE_STATE_RUNNING"
+        ]
+      },
+      {
+        "strKey": "DEVICE_STATE_TIME_DELAY_ACTIVE",
+        "wifiArrayValue": 60,
+        "notificationInfo": {
+          "necessity": null,
+          "priority": "LOW",
+          "strKey": "DEVICE_STATE_TIME_DELAY_ACTIVE_NOTIFICATION"
+        },
+        "allowedTransitions": [
+          "DEVICE_STATE_OFF",
+          "DEVICE_STATE_PAUSED"
+        ]
+      },
+      {
+        "strKey": "DEVICE_STATE_TIME_DELAY_PAUSED",
+        "wifiArrayValue": 80,
+        "notificationInfo": {
+          "necessity": null,
+          "priority": "MEDIUM",
+          "strKey": "DEVICE_STATE_TIME_DELAY_PAUSED_NOTIFICATION"
+        },
+        "allowedTransitions": [
+          "DEVICE_STATE_OFF",
+          "DEVICE_STATE_RUNNING"
+        ]
+      }
+    ],
+    "wfaIndex": null,
+    "wifiArrayWriteIndex": 34,
+    "wifiArrayReadIndex": 35
+  },
+  "deviceSubStates": {
+    "subStates": [
+      {
+        "strKey": "WASHER_SUBSTATE_WASHING",
+        "wifiArrayValue": 1
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_SPIN",
+        "wifiArrayValue": 2
+      },
+      {
+        "strKey": "WASHER_WATER_INTAKE",
+        "wifiArrayValue": 3
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_PREWASH",
+        "wifiArrayValue": 4
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_RINSING",
+        "wifiArrayValue": 5
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_SOFTENER",
+        "wifiArrayValue": 6
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_PROGRAM_STARTED",
+        "wifiArrayValue": 7
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_TIME_DELAY_ENABLED",
+        "wifiArrayValue": 8
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_PAUSED",
+        "wifiArrayValue": 9
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_ANALYSING",
+        "wifiArrayValue": 10
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_DOOR_LOCKED",
+        "wifiArrayValue": 11
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_OPENING_DOOR",
+        "wifiArrayValue": 12
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_LOCKING_DOOR",
+        "wifiArrayValue": 13
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_REMOVE_LAUNDRY",
+        "wifiArrayValue": 15
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_ADD_LAUNDRY",
+        "wifiArrayValue": 19
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_RINSE_HOLD",
+        "wifiArrayValue": 17
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_REMOTE_ANTICREASE",
+        "wifiArrayValue": 20
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_DRYING",
+        "wifiArrayValue": 21
+      },
+      {
+        "strKey": "WASHER_SUBSTATE_TIME_DELAY_PAUSED",
+        "wifiArrayValue": 22
+      }
+    ],
+    "wifiArrayReadIndex": 50
+  },
+  "ovenMeatProbeAccessory": null,
+  "autoController": null,
+  "commands": null,
+  "consumableSettings": null,
+  "customSubPrograms": [
+    {
+      "boundedValues": [
+        {
+          "factor": 1,
+          "lowerLimit": 1,
+          "step": 1,
+          "strKey": "DURATION_LEVEL",
+          "unit": "",
+          "upperLimit": 11
+        }
+      ],
+      "enumValues": [
+        {
+          "strKey": "DURATION_LEVEL_0",
+          "wifiArrayValue": 0
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "CUSTOM_DURATION_LEVEL",
+      "wifiArrayIndex": 74,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": [
+        {
+          "factor": 1,
+          "lowerLimit": 0,
+          "step": 1,
+          "strKey": "RINSE_COUNT",
+          "unit": "",
+          "upperLimit": 5
+        }
+      ],
+      "enumValues": null,
+      "isSwitch": null,
+      "strKey": "WASHER_EXTRA_RINSE_COUNT",
+      "wifiArrayIndex": 75,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "ANTICREASE_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "ANTICREASE_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_ANTICREASE",
+      "wifiArrayIndex": 64,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "SOAKING_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "SOAKING_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_SOAKING",
+      "wifiArrayIndex": 62,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    },
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "ADD_WATER_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "ADD_WATER_ON",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": 1,
+      "strKey": "WASHER_ADD_WATER",
+      "wifiArrayIndex": 60,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    }
+  ],
+  "downloadCycleSettingsModel": {
+    "strKey": "DOWNLOADABLE_CYCLE_BYTE",
+    "wifiArrayReadIndex": 76
+  },
+  "clock": null,
+  "zones": null,
+  "monitorings": null,
+  "ovenClockWifiArrayIndexes": null,
+  "ovenDownloadedAutoBakeInformation": null,
+  "ovenRecipeInformation": null,
+  "stepCooking": null,
+  "ovenTemperatureInfo": null,
+  "refrigeratorDefrostInformation": null,
+  "remoteControl": {
+    "wifiArrayReadIndex": 32,
+    "wifiArrayValue": 170
+  },
+  "screenSaver": null,
+  "settings": [
+    {
+      "boundedValues": null,
+      "enumValues": [
+        {
+          "strKey": "VOLUME_LOW",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "VOLUME_HIGH",
+          "wifiArrayValue": 1
+        }
+      ],
+      "isSwitch": null,
+      "strKey": "SETTINGS_VOLUME",
+      "wifiArrayIndex": 55,
+      "wfaWriteIndex": null,
+      "isVisible": 1
+    }
+  ],
+  "teaRecipeInformation": null,
+  "deviceWarningsExtra": null,
+  "deviceWarnings": {
+    "wifiArrayByteCount": null,
+    "warnings": [
+      {
+        "bitIndex": 0,
+        "notificationInfo": {
+          "necessity": "OPTON",
+          "priority": "HIGH",
+          "strKey": "WASHER_WARNING_DOOR_IS_OPEN_NOTIFICATION"
+        },
+        "reasonInfo": null,
+        "strKey": "WASHER_WARNING_DOOR_IS_OPEN"
+      },
+      {
+        "bitIndex": 1,
+        "notificationInfo": {
+          "necessity": "OPTON",
+          "priority": "HIGH",
+          "strKey": "WASHER_WARNING_NO_WATER_NOTIFICATION"
+        },
+        "reasonInfo": null,
+        "strKey": "WASHER_WARNING_NO_WATER"
+      },
+      {
+        "bitIndex": 2,
+        "notificationInfo": {
+          "necessity": "MANDA",
+          "priority": "BLOCKER",
+          "strKey": "WASHER_WARNING_SECURITY_NOTIFICATION"
+        },
+        "reasonInfo": null,
+        "strKey": "WASHER_WARNING_SECURITY"
+      }
+    ],
+    "wifiArrayReadIndex": 59
+  },
+  "warnings": null
+}

--- a/custom_components/homewhiz/tests/test_controls.py
+++ b/custom_components/homewhiz/tests/test_controls.py
@@ -8,7 +8,9 @@ from dacite import from_dict
 from custom_components.homewhiz.appliance_config import ApplianceConfiguration
 from custom_components.homewhiz.appliance_controls import (
     EnumControl,
+    WriteEnumControl,
     WriteTimeControl,
+    build_control_from_program,
     generate_controls_from_config,
 )
 from custom_components.homewhiz.homewhiz import Command
@@ -73,3 +75,23 @@ def test_writable_start_delay(config: ApplianceConfiguration) -> None:
     for command in delay.set_value(125):
         data[command.index] = command.value
     assert delay.get_value(data) == 125
+
+
+def test_program_options_with_duplicate_names() -> None:
+    # Issue #410: this Beko washer lists PROGRAM_MIX twice (bytes 7 and 16),
+    # which crashed every platform setup with bidict.ValueDuplicationError.
+    # The duplicate gets the wifiArrayValue suffixed instead, like the existing
+    # guard in get_options_from_feature (#273).
+    file_path = Path(__file__).parent / "fixtures" / "beko-washer-410.json"
+    with file_path.open(encoding="utf-8") as file:
+        washer_config = from_dict(ApplianceConfiguration, json.load(file))
+    control = build_control_from_program(washer_config.program)
+    assert isinstance(control, WriteEnumControl)
+    options = list(control.options.values())
+    assert len(options) == 21
+    assert "program_mix" in options
+    assert "program_mix_16" in options
+    # Both names stay individually writable: the first entry keeps the plain
+    # name (byte 7), the duplicate carries its byte value as suffix.
+    assert control.set_value("program_mix") == Command(control.write_index, 7)
+    assert control.set_value("program_mix_16") == Command(control.write_index, 16)


### PR DESCRIPTION
Fixes #410.

Some washer configs list a program option twice under the same name, which
crashed bidict during setup (no entities at all). Same fix shape as #273:
duplicate names get the wifiArrayValue suffixed instead of colliding.

Verified against the reporter's real config (34 entities, no crash).