### PR TITLE
Quiet down transient Bluetooth setup failures

### DIFF
--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -52,6 +52,14 @@ async def setup_bluetooth(
         )
     )
 
+    async def connect_retrieving_errors() -> None:
+        # connect() logs its own failure and try_reconnect takes over;
+        # retrieving the exception here avoids a duplicate traceback.
+        try:
+            await coordinator.connect()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Connect from advertisement failed, reconnect retries")
+
     @callback
     def connect(
         service_info: BluetoothServiceInfoBleak,
@@ -59,7 +67,7 @@ async def setup_bluetooth(
     ) -> None:
         if not coordinator.is_connected and not coordinator.reconnecting_lock.locked():
             _LOGGER.debug("Called connect callback in setup_bluetooth")
-            hass.async_create_task(coordinator.connect())
+            hass.async_create_task(connect_retrieving_errors())
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(

--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -119,7 +119,12 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                     response=False,
                 )
             except Exception:
-                _LOGGER.exception("Failed to set up connection, cleaning up")
+                # WARNING, not ERROR: this failure is transient and the
+                # reconnect loop takes over; a persistent problem still
+                # surfaces as ERROR via "Can't reconnect" every 30s.
+                _LOGGER.warning(
+                    "Failed to set up connection, cleaning up", exc_info=True
+                )
                 with contextlib.suppress(Exception):
                     await self._connection.disconnect()
                 self._connection = None  # ensure clean state for next attempt


### PR DESCRIPTION
A failed BLE setup logs two ERRORs: the failure itself, plus an `asyncio` "Task exception was never retrieved" traceback from the fire-and-forget connect task in the advertisement callback (#367).

This retrieves the task exception and logs the transient setup failure as a warning. The traceback stays, and a persistent failure is still an ERROR via `Can't reconnect`.