### PR TITLE
Ignore disconnect callbacks from superseded BLE clients

### DIFF
--- a/custom_components/homewhiz/bluetooth.py
+++ b/custom_components/homewhiz/bluetooth.py
@@ -176,7 +176,7 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
         if not self.alive:
             _LOGGER.debug("Disconnected callback called but not alive")
             return
-        self.hass.create_task(self.handle_disconnect())
+        self.hass.create_task(self.handle_disconnect(client))
 
     @callback
     def reconnect_callback(self, *args: Any) -> None:
@@ -214,9 +214,21 @@ class HomewhizBluetoothUpdateCoordinator(HomewhizCoordinator):
                     )
                     await asyncio.sleep(30)
 
-    async def handle_disconnect(self, *args: Any) -> None:
+    async def handle_disconnect(
+        self, client: BleakClient | None = None, *args: Any
+    ) -> None:
         _LOGGER.debug("Handling disconnect%s...", " by time interval" if args else "")
         async with self._connection_lock:
+            # Only a disconnect of the live connection may tear it down.
+            # A late callback from a superseded client would otherwise kill
+            # a fresh, healthy connection established in the meantime.
+            if (
+                client is not None
+                and self._connection is not None
+                and client is not self._connection
+            ):
+                _LOGGER.debug("Ignoring disconnect from a stale connection")
+                return
             async with self._device_lock:
                 self._device = None
             # Ensure device is disconnected

--- a/custom_components/homewhiz/tests/test_bluetooth.py
+++ b/custom_components/homewhiz/tests/test_bluetooth.py
@@ -2,9 +2,13 @@
 
 The coordinator is built without DataUpdateCoordinator.__init__, and async code
 runs through asyncio.run() from sync tests, so no extra plugin is needed.
+Setting up that state requires touching private attributes.
 """
 
+# ruff: noqa: SLF001
+
 import asyncio
+from typing import Any
 from unittest.mock import Mock
 
 from custom_components.homewhiz.bluetooth import HomewhizBluetoothUpdateCoordinator
@@ -42,8 +46,8 @@ def _make_coordinator(scheduled: list) -> HomewhizBluetoothUpdateCoordinator:
 def test_stale_client_disconnect_is_ignored() -> None:
     scheduled: list = []
     coord = _make_coordinator(scheduled)
-    superseded = _FakeClient(connected=False)
-    live = _FakeClient()
+    superseded: Any = _FakeClient(connected=False)
+    live: Any = _FakeClient()
     coord._connection = live
 
     asyncio.run(coord.handle_disconnect(superseded))
@@ -57,7 +61,7 @@ def test_stale_client_disconnect_is_ignored() -> None:
 def test_live_client_disconnect_tears_down() -> None:
     scheduled: list = []
     coord = _make_coordinator(scheduled)
-    live = _FakeClient()
+    live: Any = _FakeClient()
     coord._connection = live
 
     asyncio.run(coord.handle_disconnect(live))
@@ -72,7 +76,7 @@ def test_disconnect_without_client_tears_down() -> None:
     """Callers that pass no client (e.g. interval reconnect) keep working."""
     scheduled: list = []
     coord = _make_coordinator(scheduled)
-    live = _FakeClient()
+    live: Any = _FakeClient()
     coord._connection = live
 
     asyncio.run(coord.handle_disconnect())

--- a/custom_components/homewhiz/tests/test_bluetooth.py
+++ b/custom_components/homewhiz/tests/test_bluetooth.py
@@ -1,0 +1,83 @@
+"""Tests for the Bluetooth coordinator's disconnect handling.
+
+The coordinator is built without DataUpdateCoordinator.__init__, and async code
+runs through asyncio.run() from sync tests, so no extra plugin is needed.
+"""
+
+import asyncio
+from unittest.mock import Mock
+
+from custom_components.homewhiz.bluetooth import HomewhizBluetoothUpdateCoordinator
+
+
+class _FakeClient:
+    def __init__(self, connected: bool = True) -> None:
+        self.disconnect_calls = 0
+        self._connected = connected
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self._connected = False
+
+
+def _make_coordinator(scheduled: list) -> HomewhizBluetoothUpdateCoordinator:
+    coord = object.__new__(HomewhizBluetoothUpdateCoordinator)
+    coord.address = "00:11:22:33:44:55"
+    coord.alive = True
+    coord._connection = None
+    coord._connection_lock = asyncio.Lock()
+    coord._device = None
+    coord._device_lock = asyncio.Lock()
+    hass = Mock()
+    hass.create_task = scheduled.append
+    hass.add_job = Mock()
+    coord.hass = hass
+    return coord
+
+
+def test_stale_client_disconnect_is_ignored() -> None:
+    scheduled: list = []
+    coord = _make_coordinator(scheduled)
+    superseded = _FakeClient(connected=False)
+    live = _FakeClient()
+    coord._connection = live
+
+    asyncio.run(coord.handle_disconnect(superseded))
+    for coro in scheduled:
+        coro.close()
+
+    assert coord._connection is live
+    assert live.disconnect_calls == 0
+
+
+def test_live_client_disconnect_tears_down() -> None:
+    scheduled: list = []
+    coord = _make_coordinator(scheduled)
+    live = _FakeClient()
+    coord._connection = live
+
+    asyncio.run(coord.handle_disconnect(live))
+    for coro in scheduled:
+        coro.close()
+
+    assert coord._connection is None
+    assert live.disconnect_calls == 1
+
+
+def test_disconnect_without_client_tears_down() -> None:
+    """Callers that pass no client (e.g. interval reconnect) keep working."""
+    scheduled: list = []
+    coord = _make_coordinator(scheduled)
+    live = _FakeClient()
+    coord._connection = live
+
+    asyncio.run(coord.handle_disconnect())
+    for coro in scheduled:
+        coro.close()
+
+    assert coord._connection is None
+    assert live.disconnect_calls == 1


### PR DESCRIPTION
A late disconnect callback from a superseded client tears down the healthy connection that replaced it: `disconnected_callback` drops the client bleak passes in, so `handle_disconnect` disconnects whatever is current. The appliance then keeps its single connection slot and the reconnect loop finds nothing.

This passes the client through and ignores callbacks that are not from the live connection, checked under the connection lock. Calls without a client (interval reconnect) are unchanged.

Follow-up hardening to #388 and #398. Tests run via `asyncio.run()`, no new test dependency.