### PR TITLE
Raise a proper Home Assistant error when setup data is missing

### DIFF
--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.components.bluetooth import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.requirements import RequirementsNotFound
 from homeassistant.util.package import install_package, is_installed
 
@@ -28,7 +29,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.info("Setting up entry %s", entry.unique_id)
     address = entry.unique_id
     if "ids" not in entry.data:
-        raise Exception(
+        raise HomeAssistantError(
             "Appliance config not fetched from the API. "
             "Please configure the integration again"
         )

--- a/custom_components/homewhiz/tests/test_init.py
+++ b/custom_components/homewhiz/tests/test_init.py
@@ -1,0 +1,23 @@
+"""Tests for the entry setup guard in async_setup_entry.
+
+Only the very first branch is driven here: it raises before touching hass
+or any coordinator, so a bare Mock standing in for the config entry is
+enough.
+"""
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.homewhiz import async_setup_entry
+
+
+def test_missing_ids_raises_home_assistant_error() -> None:
+    entry = Mock()
+    entry.unique_id = "test"
+    entry.data = {}
+
+    with pytest.raises(HomeAssistantError):
+        asyncio.run(async_setup_entry(Mock(), entry))


### PR DESCRIPTION
A bare Exception gives no signal that this failure has a known cause. HomeAssistantError is the framework's class for exactly this, same message.