### PR TITLE
Fix AC instant consumption unit (kW/kWh) and add numeric fan-mode translations

### DIFF
--- a/custom_components/homewhiz/appliance_controls.py
+++ b/custom_components/homewhiz/appliance_controls.py
@@ -56,7 +56,9 @@ def to_friendly_name(name: str) -> str:
     name = name.replace("+", "plus")
     name = name.lower()
     name = re.sub("[^a-z0-9-_]", "", name)
-    return name.removesuffix("_")
+    if name[-1] == "_":
+        name = name[:-1]
+    return name
 
 
 class Control(ABC):
@@ -670,15 +672,6 @@ def get_options_from_enum_options(
     return result
 
 
-# Arcelik's own CONFIGURATION endpoint reports a wrong factor (1) for this
-# key on some AC models (e.g. Ekolojik 18325) - the user manual and the
-# on-device display confirm the real value is raw_byte * 0.1 (kW), not
-# raw_byte * 1. Override it here since we can't fix Arcelik's server data.
-KNOWN_BAD_FACTORS = {
-    "air_conditioner_instant_consumption": 0.1,
-}
-
-
 def build_read_control_from_feature(feature: ApplianceFeature) -> Control | None:
     key = feature.strKey
     if key is None:
@@ -689,13 +682,10 @@ def build_read_control_from_feature(feature: ApplianceFeature) -> Control | None
         and feature.boundedValues is not None
         and len(feature.boundedValues) == 1
     ):
-        bounds = feature.boundedValues[0]
-        if key in KNOWN_BAD_FACTORS:
-            bounds = replace(bounds, factor=KNOWN_BAD_FACTORS[key])
         return NumericControl(
             key=key,
             read_index=feature.wifiArrayIndex,
-            bounds=bounds,
+            bounds=feature.boundedValues[0],
         )
     return EnumControl(
         key=key,
@@ -1149,6 +1139,22 @@ def extract_ac_control(control_list: list[Control]) -> list[Control]:
     controls_dict = {control.key: control for control in control_list}
     keys = controls_dict.keys()
     if "air_conditioner_program" in keys:
+        # Arcelik's own CONFIGURATION endpoint reports a wrong factor (1)
+        # for AIR_CONDITIONER_INSTANT_CONSUMPTION on some AC models (e.g.
+        # Ekolojik 18325/15325) - the user manual and the on-device display
+        # confirm the real value is raw_byte * 0.1 (kW), not raw_byte * 1.
+        # Only touch this single, known-affected AC feature, and only when
+        # we see the exact known-bad factor, so appliances that already
+        # report the correct factor (or any other feature/unit) are left
+        # untouched.
+        instant_consumption = controls_dict.get("air_conditioner_instant_consumption")
+        if (
+            isinstance(instant_consumption, NumericControl)
+            and instant_consumption.bounds.unit == "hw"
+            and instant_consumption.bounds.factor == 1
+        ):
+            instant_consumption.bounds = replace(instant_consumption.bounds, factor=0.1)
+
         state = controls_dict["state"]
         assert isinstance(state, WriteBooleanControl)
         program = controls_dict["air_conditioner_program"]

--- a/custom_components/homewhiz/appliance_controls.py
+++ b/custom_components/homewhiz/appliance_controls.py
@@ -2,7 +2,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, replace
 from datetime import UTC, datetime, timedelta
 from typing import Any, Generic, TypeVar
 
@@ -672,6 +672,15 @@ def get_options_from_enum_options(
     return result
 
 
+# Arcelik's own CONFIGURATION endpoint reports a wrong factor (1) for this
+# key on some AC models (e.g. Ekolojik 18325) - the user manual and the
+# on-device display confirm the real value is raw_byte * 0.1 (kW), not
+# raw_byte * 1. Override it here since we can't fix Arcelik's server data.
+KNOWN_BAD_FACTORS = {
+    "air_conditioner_instant_consumption": 0.1,
+}
+
+
 def build_read_control_from_feature(feature: ApplianceFeature) -> Control | None:
     key = feature.strKey
     if key is None:
@@ -682,10 +691,13 @@ def build_read_control_from_feature(feature: ApplianceFeature) -> Control | None
         and feature.boundedValues is not None
         and len(feature.boundedValues) == 1
     ):
+        bounds = feature.boundedValues[0]
+        if key in KNOWN_BAD_FACTORS:
+            bounds = replace(bounds, factor=KNOWN_BAD_FACTORS[key])
         return NumericControl(
             key=key,
             read_index=feature.wifiArrayIndex,
-            bounds=feature.boundedValues[0],
+            bounds=bounds,
         )
     return EnumControl(
         key=key,

--- a/custom_components/homewhiz/appliance_controls.py
+++ b/custom_components/homewhiz/appliance_controls.py
@@ -56,9 +56,7 @@ def to_friendly_name(name: str) -> str:
     name = name.replace("+", "plus")
     name = name.lower()
     name = re.sub("[^a-z0-9-_]", "", name)
-    if name[-1] == "_":
-        name = name[:-1]
-    return name
+    return name.removesuffix("_")
 
 
 class Control(ABC):

--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -132,9 +132,7 @@ class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
         device_name: str,
         data: EntryData,
     ):
-        super().__init__(
-            coordinator, device_name, f"{power_control.key}_total", data
-        )
+        super().__init__(coordinator, device_name, f"{power_control.key}_total", data)
         self._power_control = power_control
         self._total_kwh: float = 0.0
         self._last_update: datetime | None = None
@@ -155,7 +153,7 @@ class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
         # Prime the integration baseline now, so the very first coordinator
         # update after startup doesn't integrate over the (possibly huge)
         # gap since HA was last running.
-        self._last_update = datetime.now(timezone.utc)
+        self._last_update = datetime.now(UTC)
         current = self._current_power_kw()
         if current is not None:
             self._last_power_kw = current
@@ -167,7 +165,7 @@ class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
         return float(value) if value is not None else None
 
     def _handle_coordinator_update(self) -> None:
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         power_kw = self._current_power_kw()
 
         if power_kw is not None:

--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
 
 from .appliance_controls import (
     DebugControl,
@@ -32,11 +31,13 @@ from .homewhiz import HomewhizCoordinator
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
-# If the coordinator hasn't pushed an update for longer than this, we don't
-# trust the "constant power over the gap" assumption (e.g. HA was down, or
-# the appliance dropped offline) - skip integrating that particular gap
-# instead of risking a bogus energy spike/dip on the Energy dashboard.
-MAX_INTEGRATION_GAP_HOURS = 1.0
+# The only NumericControl currently known to need a corrected unit/device
+# class. Arcelik's CONFIGURATION endpoint reports this field with a "hw"
+# unit label (see the matching factor fix in appliance_controls.py's
+# extract_ac_control) which isn't a real HA unit, so we map it to kW here.
+# Scoped to this single key on purpose - other NumericControl sensors keep
+# their previous (no explicit unit/device_class) behavior.
+INSTANT_CONSUMPTION_KEY = "air_conditioner_instant_consumption"
 
 
 class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
@@ -61,19 +62,13 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         elif isinstance(control, EnumControl):
             self._attr_device_class = SensorDeviceClass.ENUM  # type:ignore
             self._attr_options = list(self._control.options.values())  # type:ignore
-        elif isinstance(control, NumericControl):
-            unit = control.bounds.unit
-            # Arcelik reports this consumption field with an unusable "hw"
-            # unit label; the value itself is corrected to real kW via the
-            # factor override in appliance_controls.py, so show it as kW.
-            if unit == "hw":
-                unit = "kW"
-                self._attr_device_class = SensorDeviceClass.POWER
-                self._attr_state_class = SensorStateClass.MEASUREMENT
-            elif unit == "°C":
-                self._attr_device_class = SensorDeviceClass.TEMPERATURE
-            if unit:
-                self._attr_native_unit_of_measurement = unit
+        elif (
+            isinstance(control, NumericControl)
+            and control.key == INSTANT_CONSUMPTION_KEY
+        ):
+            self._attr_native_unit_of_measurement = "kW"
+            self._attr_device_class = SensorDeviceClass.POWER
+            self._attr_state_class = SensorStateClass.MEASUREMENT
         elif isinstance(control, SummedTimestampControl):
             self._attr_icon = "mdi:camera-timer"
             self._attr_device_class = SensorDeviceClass.TIMESTAMP
@@ -109,88 +104,6 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         return self._control.get_value(self.coordinator.data)
 
 
-class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
-    """Integrates an instantaneous power (kW) NumericControl over time into
-    an accumulated kWh total, ready to be added to the HA Energy dashboard.
-
-    The appliance itself does not report a running kWh total, only
-    instantaneous power - this entity does a trapezoidal integration of
-    that value every time the coordinator pushes new data, and persists
-    the running total across HA restarts via RestoreEntity so it behaves
-    like a proper "total_increasing" energy meter.
-    """
-
-    _attr_device_class = SensorDeviceClass.ENERGY
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = "kWh"
-    _attr_icon = "mdi:lightning-bolt"
-
-    def __init__(
-        self,
-        coordinator: HomewhizCoordinator,
-        power_control: NumericControl,
-        device_name: str,
-        data: EntryData,
-    ):
-        super().__init__(coordinator, device_name, f"{power_control.key}_total", data)
-        # HomeWhizEntity.__init__ (called just above) unconditionally sets
-        # self._attr_device_class to a homewhiz-internal placeholder value,
-        # clobbering the SensorDeviceClass.ENERGY class attribute defined
-        # above. Re-assert it here so HA recognizes this as a proper energy
-        # sensor (otherwise the Energy dashboard rejects it with
-        # "Unexpected device class").
-        self._attr_device_class = SensorDeviceClass.ENERGY
-        self._power_control = power_control
-        self._total_kwh: float = 0.0
-        self._last_update: datetime | None = None
-        self._last_power_kw: float | None = None
-
-    async def async_added_to_hass(self) -> None:
-        await super().async_added_to_hass()
-        last_state = await self.async_get_last_state()
-        if last_state is not None and last_state.state not in (
-            None,
-            "unknown",
-            "unavailable",
-        ):
-            try:
-                self._total_kwh = float(last_state.state)
-            except (TypeError, ValueError):
-                self._total_kwh = 0.0
-        # Prime the integration baseline now, so the very first coordinator
-        # update after startup doesn't integrate over the (possibly huge)
-        # gap since HA was last running.
-        self._last_update = datetime.now(UTC)
-        current = self._current_power_kw()
-        if current is not None:
-            self._last_power_kw = current
-
-    def _current_power_kw(self) -> float | None:
-        if self.coordinator.data is None:
-            return None
-        value = self._power_control.get_value(self.coordinator.data)
-        return float(value) if value is not None else None
-
-    def _handle_coordinator_update(self) -> None:
-        now = datetime.now(UTC)
-        power_kw = self._current_power_kw()
-
-        if power_kw is not None:
-            if self._last_update is not None and self._last_power_kw is not None:
-                elapsed_hours = (now - self._last_update).total_seconds() / 3600
-                if 0 < elapsed_hours <= MAX_INTEGRATION_GAP_HOURS:
-                    avg_power_kw = (self._last_power_kw + power_kw) / 2
-                    self._total_kwh += avg_power_kw * elapsed_hours
-            self._last_power_kw = power_kw
-            self._last_update = now
-
-        super()._handle_coordinator_update()
-
-    @property
-    def native_value(self) -> float:  # type: ignore[override]
-        return round(self._total_kwh, 4)
-
-
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -216,23 +129,10 @@ async def async_setup_entry(
 
     _LOGGER.debug("Sensors: %s", [c.key for c in sensor_controls])
 
-    homewhiz_sensor_entities: list[HomeWhizSensorEntity | HomeWhizEnergyEntity] = [
+    homewhiz_sensor_entities = [
         HomeWhizSensorEntity(coordinator, control, entry.title, data)
         for control in sensor_controls
     ]
-
-    # For every instantaneous power ("hw" -> kW) control, also add a
-    # companion kWh accumulator entity for the Energy dashboard.
-    power_controls = [
-        c
-        for c in sensor_controls
-        if isinstance(c, NumericControl) and c.bounds.unit == "hw"
-    ]
-    homewhiz_sensor_entities.extend(
-        HomeWhizEnergyEntity(coordinator, control, entry.title, data)
-        for control in power_controls
-    )
-
     _LOGGER.debug(
         "Entities: %s",
         {entity.entity_key: entity for entity in homewhiz_sensor_entities},

--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -133,6 +133,13 @@ class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
         data: EntryData,
     ):
         super().__init__(coordinator, device_name, f"{power_control.key}_total", data)
+        # HomeWhizEntity.__init__ (called just above) unconditionally sets
+        # self._attr_device_class to a homewhiz-internal placeholder value,
+        # clobbering the SensorDeviceClass.ENERGY class attribute defined
+        # above. Re-assert it here so HA recognizes this as a proper energy
+        # sensor (otherwise the Energy dashboard rejects it with
+        # "Unexpected device class").
+        self._attr_device_class = SensorDeviceClass.ENERGY
         self._power_control = power_control
         self._total_kwh: float = 0.0
         self._last_update: datetime | None = None

--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .appliance_controls import (
     DebugControl,
@@ -26,6 +31,12 @@ from .helper import build_entry_data
 from .homewhiz import HomewhizCoordinator
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+# If the coordinator hasn't pushed an update for longer than this, we don't
+# trust the "constant power over the gap" assumption (e.g. HA was down, or
+# the appliance dropped offline) - skip integrating that particular gap
+# instead of risking a bogus energy spike/dip on the Energy dashboard.
+MAX_INTEGRATION_GAP_HOURS = 1.0
 
 
 class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
@@ -50,6 +61,19 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         elif isinstance(control, EnumControl):
             self._attr_device_class = SensorDeviceClass.ENUM  # type:ignore
             self._attr_options = list(self._control.options.values())  # type:ignore
+        elif isinstance(control, NumericControl):
+            unit = control.bounds.unit
+            # Arcelik reports this consumption field with an unusable "hw"
+            # unit label; the value itself is corrected to real kW via the
+            # factor override in appliance_controls.py, so show it as kW.
+            if unit == "hw":
+                unit = "kW"
+                self._attr_device_class = SensorDeviceClass.POWER
+                self._attr_state_class = SensorStateClass.MEASUREMENT
+            elif unit == "°C":
+                self._attr_device_class = SensorDeviceClass.TEMPERATURE
+            if unit:
+                self._attr_native_unit_of_measurement = unit
         elif isinstance(control, SummedTimestampControl):
             self._attr_icon = "mdi:camera-timer"
             self._attr_device_class = SensorDeviceClass.TIMESTAMP
@@ -85,6 +109,83 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         return self._control.get_value(self.coordinator.data)
 
 
+class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
+    """Integrates an instantaneous power (kW) NumericControl over time into
+    an accumulated kWh total, ready to be added to the HA Energy dashboard.
+
+    The appliance itself does not report a running kWh total, only
+    instantaneous power - this entity does a trapezoidal integration of
+    that value every time the coordinator pushes new data, and persists
+    the running total across HA restarts via RestoreEntity so it behaves
+    like a proper "total_increasing" energy meter.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_icon = "mdi:lightning-bolt"
+
+    def __init__(
+        self,
+        coordinator: HomewhizCoordinator,
+        power_control: NumericControl,
+        device_name: str,
+        data: EntryData,
+    ):
+        super().__init__(
+            coordinator, device_name, f"{power_control.key}_total", data
+        )
+        self._power_control = power_control
+        self._total_kwh: float = 0.0
+        self._last_update: datetime | None = None
+        self._last_power_kw: float | None = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state not in (
+            None,
+            "unknown",
+            "unavailable",
+        ):
+            try:
+                self._total_kwh = float(last_state.state)
+            except (TypeError, ValueError):
+                self._total_kwh = 0.0
+        # Prime the integration baseline now, so the very first coordinator
+        # update after startup doesn't integrate over the (possibly huge)
+        # gap since HA was last running.
+        self._last_update = datetime.now(timezone.utc)
+        current = self._current_power_kw()
+        if current is not None:
+            self._last_power_kw = current
+
+    def _current_power_kw(self) -> float | None:
+        if self.coordinator.data is None:
+            return None
+        value = self._power_control.get_value(self.coordinator.data)
+        return float(value) if value is not None else None
+
+    def _handle_coordinator_update(self) -> None:
+        now = datetime.now(timezone.utc)
+        power_kw = self._current_power_kw()
+
+        if power_kw is not None:
+            if self._last_update is not None and self._last_power_kw is not None:
+                elapsed_hours = (now - self._last_update).total_seconds() / 3600
+                if 0 < elapsed_hours <= MAX_INTEGRATION_GAP_HOURS:
+                    avg_power_kw = (self._last_power_kw + power_kw) / 2
+                    self._total_kwh += avg_power_kw * elapsed_hours
+            self._last_power_kw = power_kw
+            self._last_update = now
+
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self) -> float:  # type: ignore[override]
+        return round(self._total_kwh, 4)
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -110,10 +211,23 @@ async def async_setup_entry(
 
     _LOGGER.debug("Sensors: %s", [c.key for c in sensor_controls])
 
-    homewhiz_sensor_entities = [
+    homewhiz_sensor_entities: list[HomeWhizSensorEntity | HomeWhizEnergyEntity] = [
         HomeWhizSensorEntity(coordinator, control, entry.title, data)
         for control in sensor_controls
     ]
+
+    # For every instantaneous power ("hw" -> kW) control, also add a
+    # companion kWh accumulator entity for the Energy dashboard.
+    power_controls = [
+        c
+        for c in sensor_controls
+        if isinstance(c, NumericControl) and c.bounds.unit == "hw"
+    ]
+    homewhiz_sensor_entities.extend(
+        HomeWhizEnergyEntity(coordinator, control, entry.title, data)
+        for control in power_controls
+    )
+
     _LOGGER.debug(
         "Entities: %s",
         {entity.entity_key: entity for entity in homewhiz_sensor_entities},

--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -38,6 +38,9 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 # Scoped to this single key on purpose - other NumericControl sensors keep
 # their previous (no explicit unit/device_class) behavior.
 INSTANT_CONSUMPTION_KEY = "air_conditioner_instant_consumption"
+# The bogus unit label that marks the affected reports. A device sending the
+# same key with a real unit is left alone, matching the factor fix.
+INSTANT_CONSUMPTION_BOGUS_UNIT = "hw"
 
 
 class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
@@ -65,6 +68,7 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         elif (
             isinstance(control, NumericControl)
             and control.key == INSTANT_CONSUMPTION_KEY
+            and control.bounds.unit == INSTANT_CONSUMPTION_BOGUS_UNIT
         ):
             self._attr_native_unit_of_measurement = "kW"
             self._attr_device_class = SensorDeviceClass.POWER

--- a/custom_components/homewhiz/tests/fixtures/example_ac_advanced_config_correct_factor.json
+++ b/custom_components/homewhiz/tests/fixtures/example_ac_advanced_config_correct_factor.json
@@ -1,0 +1,427 @@
+{
+  "program": {
+    "strKey": "AIR_CONDITIONER_PROGRAM",
+    "wifiArrayIndex": 34,
+    "values": [
+      {
+        "strKey": "AIR_CONDITIONER_MODE_COOLING",
+        "wifiArrayValue": 0,
+        "subProgramOverrides": [
+          {
+            "strKeyRef": "AIR_CONDITIONER_TARGET_TEMPERATURE",
+            "allowedValueIndices": [
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ]
+          }
+        ]
+      },
+      {
+        "strKey": "AIR_CONDITIONER_MODE_AUTO",
+        "wifiArrayValue": 6,
+        "subProgramOverrides": [
+          {
+            "strKeyRef": "AIR_CONDITIONER_JET_MODE",
+            "isDisabled": 1
+          },
+          {
+            "strKeyRef": "AIR_CONDITIONER_TARGET_TEMPERATURE",
+            "allowedValueIndices": [
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              8,
+              9,
+              10,
+              11,
+              12,
+              13,
+              14
+            ]
+          }
+        ]
+      },
+      {
+        "strKey": "AIR_CONDITIONER_MODE_DEHUMIDIFICATION",
+        "wifiArrayValue": 1,
+        "subProgramOverrides": [
+          {
+            "strKeyRef": "AIR_CONDITIONER_TARGET_TEMPERATURE",
+            "isDisabled": 1
+          },
+          {
+            "strKeyRef": "AIR_CONDITIONER_JET_MODE",
+            "isDisabled": 1
+          }
+        ]
+      },
+      {
+        "strKey": "AIR_CONDITIONER_MODE_HEATING",
+        "wifiArrayValue": 4,
+        "subProgramOverrides": []
+      },
+      {
+        "strKey": "AIR_CONDITIONER_MODE_FAN",
+        "wifiArrayValue": 2,
+        "subProgramOverrides": [
+          {
+            "strKeyRef": "AIR_CONDITIONER_TARGET_TEMPERATURE",
+            "isDisabled": 1
+          },
+          {
+            "strKeyRef": "AIR_CONDITIONER_JET_MODE",
+            "isDisabled": 1
+          }
+        ]
+      }
+    ]
+  },
+  "subPrograms": [
+    {
+      "strKey": "AIR_CONDITIONER_TARGET_TEMPERATURE",
+      "wifiArrayIndex": 35,
+      "isSwitch": 0,
+      "boundedValues": [
+        {
+          "strKey": "AIR_CONDITIONER_TARGET_TEMPERATURE",
+          "lowerLimit": 16,
+          "upperLimit": 30,
+          "step": 1,
+          "factor": 0.5,
+          "unit": ""
+        }
+      ]
+    },
+    {
+      "strKey": "AIR_CONDITIONER_WIND_STRENGTH",
+      "wifiArrayIndex": 36,
+      "isSwitch": 0,
+      "boundedValues": [
+        {
+          "strKey": "WIND_STRENGTH",
+          "lowerLimit": 2,
+          "upperLimit": 6,
+          "step": 1,
+          "factor": 1,
+          "unit": ""
+        }
+      ],
+      "enumValues": [
+        {
+          "strKey": "WIND_STRENGTH_CHAOS_SWING",
+          "wifiArrayValue": 8
+        }
+      ]
+    },
+    {
+      "strKey": "AIR_CONDITIONER_JET_MODE",
+      "wifiArrayIndex": 37,
+      "isSwitch": 1,
+      "enumValues": [
+        {
+          "strKey": "AIR_CONDITIONER_JET_MODE_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "AIR_CONDITIONER_JET_MODE_ON",
+          "wifiArrayValue": 1
+        }
+      ]
+    },
+    {
+      "strKey": "AIR_CONDITIONER_SOFT_AIR",
+      "wifiArrayIndex": 46,
+      "isSwitch": 0,
+      "enumValues": [
+        {
+          "strKey": "AIR_CONDITIONER_SOFT_AIR_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "AIR_CONDITIONER_SOFT_AIR_UP",
+          "wifiArrayValue": 1
+        },
+        {
+          "strKey": "AIR_CONDITIONER_SOFT_AIR_DOWN",
+          "wifiArrayValue": 6
+        }
+      ]
+    },
+    {
+      "strKey": "AIR_CONDITIONER_UP_DOWN_VANE_CONTROL",
+      "wifiArrayIndex": 38,
+      "isSwitch": 0,
+      "enumValues": [
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_1",
+          "wifiArrayValue": 6
+        },
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_2",
+          "wifiArrayValue": 5
+        },
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_3",
+          "wifiArrayValue": 4
+        },
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_4",
+          "wifiArrayValue": 3
+        },
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_5",
+          "wifiArrayValue": 2
+        },
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_6",
+          "wifiArrayValue": 1
+        },
+        {
+          "strKey": "UP_DOWN_VANE_CONTROL_AUTO",
+          "wifiArrayValue": 100
+        }
+      ]
+    },
+    {
+      "strKey": "AIR_CONDITIONER_LEFT_RIGHT_VANE_CONTROL",
+      "wifiArrayIndex": 39,
+      "isSwitch": 0,
+      "enumValues": [
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_OFF",
+          "wifiArrayValue": 0
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_1",
+          "wifiArrayValue": 1
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_2",
+          "wifiArrayValue": 2
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_3",
+          "wifiArrayValue": 3
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_4",
+          "wifiArrayValue": 4
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_5",
+          "wifiArrayValue": 5
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_LEFT",
+          "wifiArrayValue": 13
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_RIGHT",
+          "wifiArrayValue": 35
+        },
+        {
+          "strKey": "LEFT_RIGHT_VANE_CONTROL_AUTO",
+          "wifiArrayValue": 100
+        }
+      ]
+    }
+  ],
+  "progressVariables": {
+    "sleepMode": {
+      "strKey": "AIR_CONDITIONER_SLEEP_MODE",
+      "isVisible": 1,
+      "isExpandableBySwitch": 1,
+      "isAlwaysAvailable": 0,
+      "hour": {
+        "wifiArrayIndex": 48,
+        "boundedValues": [
+          {
+            "strKey": "HOUR",
+            "lowerLimit": 0,
+            "upperLimit": 7,
+            "step": 1,
+            "factor": 1,
+            "unit": ""
+          }
+        ]
+      },
+      "minute": {
+        "wifiArrayIndex": 49,
+        "boundedValues": [
+          {
+            "strKey": "MINUTE",
+            "lowerLimit": 0,
+            "upperLimit": 59,
+            "step": 1,
+            "factor": 1,
+            "unit": ""
+          }
+        ]
+      }
+    },
+    "autoOn": {
+      "strKey": "AIR_CONDITIONER_AUTO_SWITCH_ON",
+      "isVisible": 1,
+      "isExpandableBySwitch": 1,
+      "isAlwaysAvailable": 1,
+      "hour": {
+        "wifiArrayIndex": 50,
+        "boundedValues": [
+          {
+            "strKey": "HOUR",
+            "lowerLimit": 0,
+            "upperLimit": 23,
+            "step": 1,
+            "factor": 1,
+            "unit": ""
+          }
+        ]
+      },
+      "minute": {
+        "wifiArrayIndex": 51,
+        "boundedValues": [
+          {
+            "strKey": "MINUTE",
+            "lowerLimit": 0,
+            "upperLimit": 59,
+            "step": 1,
+            "factor": 1,
+            "unit": ""
+          }
+        ]
+      }
+    },
+    "autoOff": {
+      "strKey": "AIR_CONDITIONER_AUTO_SWITCH_OFF",
+      "isVisible": 1,
+      "isExpandableBySwitch": 1,
+      "isAlwaysAvailable": 1,
+      "hour": {
+        "wifiArrayIndex": 52,
+        "boundedValues": [
+          {
+            "strKey": "HOUR",
+            "lowerLimit": 0,
+            "upperLimit": 23,
+            "step": 1,
+            "factor": 1,
+            "unit": ""
+          }
+        ]
+      },
+      "minute": {
+        "wifiArrayIndex": 53,
+        "boundedValues": [
+          {
+            "strKey": "MINUTE",
+            "lowerLimit": 0,
+            "upperLimit": 59,
+            "step": 1,
+            "factor": 1,
+            "unit": ""
+          }
+        ]
+      }
+    }
+  },
+  "deviceStates": {
+    "wifiArrayReadIndex": 43,
+    "wifiArrayWriteIndex": 44,
+    "states": [
+      {
+        "strKey": "DEVICE_STATE_ON",
+        "wifiArrayValue": 10,
+        "allowedTransitions": [
+          "DEVICE_STATE_OFF"
+        ],
+        "notificationInfo": {
+          "strKey": "DEVICE_STATE_ON_NOTIFICATION",
+          "priority": "LOW"
+        }
+      },
+      {
+        "strKey": "DEVICE_STATE_OFF",
+        "wifiArrayValue": 20,
+        "allowedTransitions": [
+          "DEVICE_STATE_ON"
+        ],
+        "notificationInfo": {
+          "strKey": "DEVICE_STATE_OFF_NOTIFICATION",
+          "priority": "LOW"
+        }
+      }
+    ]
+  },
+  "monitorings": [
+    {
+      "strKey": "AIR_CONDITIONER_ROOM_TEMPERATURE",
+      "wifiArrayIndex": 40,
+      "isSwitch": 0,
+      "boundedValues": [
+        {
+          "strKey": "",
+          "lowerLimit": 0,
+          "upperLimit": 100,
+          "step": 0.5,
+          "factor": 0.5,
+          "unit": "°C"
+        }
+      ]
+    },
+    {
+      "strKey": "AIR_CONDITIONER_INSTANT_CONSUMPTION",
+      "wifiArrayIndex": 45,
+      "isSwitch": 0,
+      "boundedValues": [
+        {
+          "strKey": "",
+          "lowerLimit": 0,
+          "upperLimit": 500,
+          "step": 1,
+          "factor": 0.1,
+          "unit": "hw"
+        }
+      ]
+    },
+    {
+      "strKey": "AIR_CONDITIONER_SLEEP_MODE_MINUTE",
+      "wifiArrayIndex": 49,
+      "isSwitch": 0,
+      "boundedValues": [
+        {
+          "strKey": "AIR_CONDITIONER_SLEEP_MODE_MINUTE",
+          "lowerLimit": 0,
+          "upperLimit": 59,
+          "step": 1,
+          "factor": 1,
+          "unit": ""
+        }
+      ]
+    }
+  ],
+  "deviceWarnings": {
+    "wifiArrayReadIndex": 56,
+    "warnings": []
+  },
+  "autoController": {
+    "hasAutoController": true
+  }
+}

--- a/custom_components/homewhiz/tests/test_advanced_ac.py
+++ b/custom_components/homewhiz/tests/test_advanced_ac.py
@@ -17,6 +17,7 @@ from homeassistant.components.climate import (  # type: ignore[import]
 from custom_components.homewhiz.appliance_config import ApplianceConfiguration
 from custom_components.homewhiz.appliance_controls import (
     ClimateControl,
+    NumericControl,
     generate_controls_from_config,
 )
 from custom_components.homewhiz.homewhiz import Command
@@ -65,6 +66,21 @@ data_jet_mode_on = bytearray(
 @pytest.fixture
 def config() -> ApplianceConfiguration:
     file_path = Path(__file__).parent / "fixtures/example_ac_advanced_config.json"
+    with file_path.open() as file:
+        json_content = json.load(file)
+        return from_dict(ApplianceConfiguration, json_content)
+
+
+@pytest.fixture
+def config_with_correct_consumption_factor() -> ApplianceConfiguration:
+    """Same fixture as `config`, except AIR_CONDITIONER_INSTANT_CONSUMPTION
+    already reports the correct factor (0.1) instead of the known-bad 1.
+    Used to prove the correction in extract_ac_control is a no-op once
+    Arcelik's own data is already correct."""
+    file_path = (
+        Path(__file__).parent
+        / "fixtures/example_ac_advanced_config_correct_factor.json"
+    )
     with file_path.open() as file:
         json_content = json.load(file)
         return from_dict(ApplianceConfiguration, json_content)
@@ -203,3 +219,66 @@ def test_preset_control(config: ApplianceConfiguration) -> None:
         preset_control.set_value(PRESET_NONE),
         [Command(index=37, value=0)],
     )
+
+
+def test_instant_consumption_factor_is_corrected(
+    config: ApplianceConfiguration,
+) -> None:
+    """Arcelik's CONFIGURATION reports factor=1 for
+    AIR_CONDITIONER_INSTANT_CONSUMPTION, but the real-world value
+    (confirmed against the appliance's own user manual and its on-device
+    remote display) is raw_byte * 0.1 kW. extract_ac_control corrects
+    this for AC appliances only."""
+    controls = generate_controls_from_config(
+        "ac_advanced_test_instant_consumption_bad_factor", config
+    )
+    controls_map = {control.key: control for control in controls}
+    consumption_control = controls_map["air_conditioner_instant_consumption"]
+    assert isinstance(consumption_control, NumericControl)
+
+    test_case.assertEqual(consumption_control.bounds.factor, 0.1)
+
+    data = bytearray(data_swing_both)
+    data[45] = 4
+    consumption_value = consumption_control.get_value(data)
+    assert consumption_value is not None
+    test_case.assertAlmostEqual(consumption_value, 0.4)
+
+
+def test_instant_consumption_factor_correction_is_idempotent(
+    config_with_correct_consumption_factor: ApplianceConfiguration,
+) -> None:
+    """If Arcelik ever reports the already-correct factor (0.1), the
+    correction must not touch it further (e.g. must not divide it again)."""
+    controls = generate_controls_from_config(
+        "ac_advanced_test_instant_consumption_correct_factor",
+        config_with_correct_consumption_factor,
+    )
+    controls_map = {control.key: control for control in controls}
+    consumption_control = controls_map["air_conditioner_instant_consumption"]
+    assert isinstance(consumption_control, NumericControl)
+
+    test_case.assertEqual(consumption_control.bounds.factor, 0.1)
+
+    data = bytearray(data_swing_both)
+    data[45] = 4
+    consumption_value = consumption_control.get_value(data)
+    assert consumption_value is not None
+    test_case.assertAlmostEqual(consumption_value, 0.4)
+
+
+def test_unrelated_numeric_controls_are_not_touched(
+    config: ApplianceConfiguration,
+) -> None:
+    """The instant-consumption factor correction must be scoped to that one
+    feature only - other NumericControl features (e.g. sleep mode minutes)
+    must keep whatever factor/unit Arcelik's CONFIGURATION reports."""
+    controls = generate_controls_from_config(
+        "ac_advanced_test_unrelated_numeric_controls", config
+    )
+    controls_map = {control.key: control for control in controls}
+    sleep_mode_minute = controls_map["air_conditioner_sleep_mode_minute"]
+    assert isinstance(sleep_mode_minute, NumericControl)
+
+    test_case.assertEqual(sleep_mode_minute.bounds.factor, 1)
+    test_case.assertEqual(sleep_mode_minute.bounds.unit, "")

--- a/custom_components/homewhiz/tests/test_sensor.py
+++ b/custom_components/homewhiz/tests/test_sensor.py
@@ -78,3 +78,32 @@ def test_unrelated_numeric_control_sensor_keeps_previous_behavior() -> None:
     # the one instant_consumption key, left untouched by this PR.
     assert entity.device_class == f"{DOMAIN}__{control.key}"
     assert entity.state_class is None
+
+
+def test_instant_consumption_sensor_with_a_real_unit_is_left_alone() -> None:
+    """The known-bad signature is the key plus the bogus "hw" unit label. A
+    device reporting the same key with a real unit must keep its previous
+    behavior, matching the factor correction in extract_ac_control."""
+    control = NumericControl(
+        key="air_conditioner_instant_consumption",
+        read_index=45,
+        bounds=ApplianceFeatureBoundedOption(
+            factor=1,
+            lowerLimit=0,
+            step=1,
+            strKey="",
+            unit="W",
+            upperLimit=500,
+        ),
+    )
+
+    entity = HomeWhizSensorEntity(
+        coordinator=Mock(),
+        control=control,
+        device_name="Test AC",
+        data=_entry_data(),
+    )
+
+    assert entity.native_unit_of_measurement is None
+    assert entity.device_class == f"{DOMAIN}__{control.key}"
+    assert entity.state_class is None

--- a/custom_components/homewhiz/tests/test_sensor.py
+++ b/custom_components/homewhiz/tests/test_sensor.py
@@ -1,0 +1,80 @@
+from unittest.mock import Mock
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+from custom_components.homewhiz.api import ApplianceContents
+from custom_components.homewhiz.appliance_config import ApplianceFeatureBoundedOption
+from custom_components.homewhiz.appliance_controls import NumericControl
+from custom_components.homewhiz.config_flow import EntryData
+from custom_components.homewhiz.const import DOMAIN
+from custom_components.homewhiz.sensor import HomeWhizSensorEntity
+
+
+def _entry_data() -> EntryData:
+    return EntryData(
+        ids=Mock(),
+        contents=ApplianceContents(config=Mock(), localization={}),
+        appliance_info=None,
+        cloud_config=None,
+    )
+
+
+def test_instant_consumption_sensor_reports_kw_power_measurement() -> None:
+    control = NumericControl(
+        key="air_conditioner_instant_consumption",
+        read_index=45,
+        bounds=ApplianceFeatureBoundedOption(
+            factor=0.1,
+            lowerLimit=0,
+            step=1,
+            strKey="",
+            unit="hw",
+            upperLimit=500,
+        ),
+    )
+
+    entity = HomeWhizSensorEntity(
+        coordinator=Mock(),
+        control=control,
+        device_name="Test AC",
+        data=_entry_data(),
+    )
+
+    assert entity.native_unit_of_measurement == "kW"
+    assert entity.device_class == SensorDeviceClass.POWER
+    assert entity.state_class == SensorStateClass.MEASUREMENT
+
+
+def test_unrelated_numeric_control_sensor_keeps_previous_behavior() -> None:
+    """Only the instant_consumption key should get the kW/POWER/MEASUREMENT
+    treatment - any other NumericControl (e.g. room temperature) must not
+    get an explicit native_unit_of_measurement or device_class assigned by
+    HomeWhizSensorEntity, matching pre-existing (pre-fix) behavior."""
+    control = NumericControl(
+        key="air_conditioner_room_temperature",
+        read_index=40,
+        bounds=ApplianceFeatureBoundedOption(
+            factor=0.5,
+            lowerLimit=0,
+            step=0.5,
+            strKey="",
+            unit="°C",
+            upperLimit=100,
+        ),
+    )
+
+    entity = HomeWhizSensorEntity(
+        coordinator=Mock(),
+        control=control,
+        device_name="Test AC",
+        data=_entry_data(),
+    )
+
+    assert entity.native_unit_of_measurement is None
+    # HomeWhizEntity's base __init__ always sets a homewhiz-internal
+    # placeholder device_class (f"{DOMAIN}__{entity_key}") that no branch
+    # in HomeWhizSensorEntity overrides for this control - this is the
+    # pre-existing (pre-fix) behavior for any NumericControl other than
+    # the one instant_consumption key, left untouched by this PR.
+    assert entity.device_class == f"{DOMAIN}__{control.key}"
+    assert entity.state_class is None

--- a/custom_components/homewhiz/translations/de.json
+++ b/custom_components/homewhiz/translations/de.json
@@ -1195,7 +1195,13 @@
               "wind_strength_auto": "Auto",
               "wind_strength_low": "Niedrig",
               "wind_strength_mid": "Mittel",
-              "wind_strength_high": "Hoch"
+              "wind_strength_high": "Hoch",
+              "2": "1",
+              "3": "2",
+              "4": "3",
+              "5": "4",
+              "6": "5",
+              "wind_strength_chaos_swing": "Chaos Swing"
             }
           }
         },

--- a/custom_components/homewhiz/translations/en.json
+++ b/custom_components/homewhiz/translations/en.json
@@ -1026,9 +1026,6 @@
       "air_conditioner_instant_consumption": {
         "name": "Instant Consumption"
       },
-      "air_conditioner_instant_consumption_total": {
-        "name": "Total Energy Consumption"
-      },
       "air_conditioner_sleep_mode_minute": {
         "name": "Air conditioner sleep mode minute"
       },

--- a/custom_components/homewhiz/translations/en.json
+++ b/custom_components/homewhiz/translations/en.json
@@ -1024,7 +1024,10 @@
         }
       },
       "air_conditioner_instant_consumption": {
-        "name": "Air conditioner instant consumption"
+        "name": "Instant Consumption"
+      },
+      "air_conditioner_instant_consumption_total": {
+        "name": "Total Energy Consumption"
       },
       "air_conditioner_sleep_mode_minute": {
         "name": "Air conditioner sleep mode minute"
@@ -1195,7 +1198,13 @@
               "wind_strength_auto": "Auto",
               "wind_strength_low": "Low",
               "wind_strength_mid": "Medium",
-              "wind_strength_high": "High"
+              "wind_strength_high": "High",
+              "2": "1",
+              "3": "2",
+              "4": "3",
+              "5": "4",
+              "6": "5",
+              "wind_strength_chaos_swing": "Chaos Swing"
             }
           }
         },

--- a/custom_components/homewhiz/translations/ru.json
+++ b/custom_components/homewhiz/translations/ru.json
@@ -818,7 +818,13 @@
               "wind_strength_auto": "Авто",
               "wind_strength_low": "Низкая",
               "wind_strength_mid": "Средняя",
-              "wind_strength_high": "Высокая"
+              "wind_strength_high": "Высокая",
+              "2": "1",
+              "3": "2",
+              "4": "3",
+              "5": "4",
+              "6": "5",
+              "wind_strength_chaos_swing": "Chaos Swing"
             }
           }
         },

--- a/custom_components/homewhiz/translations/sk.json
+++ b/custom_components/homewhiz/translations/sk.json
@@ -925,7 +925,13 @@
               "wind_strength_auto": "Auto",
               "wind_strength_low": "Nízke",
               "wind_strength_mid": "Stredné",
-              "wind_strength_high": "Vysoké"
+              "wind_strength_high": "Vysoké",
+              "2": "1",
+              "3": "2",
+              "4": "3",
+              "5": "4",
+              "6": "5",
+              "wind_strength_chaos_swing": "Chaos Swing"
             }
           }
         },

--- a/custom_components/homewhiz/translations/tr.json
+++ b/custom_components/homewhiz/translations/tr.json
@@ -717,7 +717,10 @@
         }
       },
       "air_conditioner_instant_consumption": {
-        "name": "Klima anlık tüketimi"
+        "name": "Anlık Tüketim"
+      },
+      "air_conditioner_instant_consumption_total": {
+        "name": "Toplam Enerji Tüketimi"
       },
       "air_conditioner_sleep_mode_minute": {
         "name": "Klima uyku modu dakika"
@@ -775,7 +778,20 @@
     },
     "climate": {
       "ac": {
-        "name": "AC"
+        "name": "AC",
+        "state_attributes": {
+          "fan_mode": {
+            "name": "Fan Hızı",
+            "state": {
+              "2": "1",
+              "3": "2",
+              "4": "3",
+              "5": "4",
+              "6": "5",
+              "wind_strength_chaos_swing": "Otomatik"
+            }
+          }
+        }
       }
     },
     "switch": {

--- a/custom_components/homewhiz/translations/tr.json
+++ b/custom_components/homewhiz/translations/tr.json
@@ -719,9 +719,6 @@
       "air_conditioner_instant_consumption": {
         "name": "Anlık Tüketim"
       },
-      "air_conditioner_instant_consumption_total": {
-        "name": "Toplam Enerji Tüketimi"
-      },
       "air_conditioner_sleep_mode_minute": {
         "name": "Klima uyku modu dakika"
       },


### PR DESCRIPTION
## Problem

On some AC models (tested on Arcelik Ekolojik 18325 and 15325), two issues:

1. **Wrong power/energy unit.** `AIR_CONDITIONER_INSTANT_CONSUMPTION`'s
   CONFIGURATION JSON reports `factor: 1, unit: "hw"`. That "hw" unit isn't
   surfaced anywhere (`NumericControl` sensors never got a
   `native_unit_of_measurement`), so the sensor just showed a raw, unitless
   number (e.g. `4`). I confirmed against the appliance's own user manual
   and the on-device remote display that the real value is
   `raw_byte * 0.1` **kW** (raw `4` → `0.4 kW`), not `raw_byte * 1`. So
   Arcelik's own server-side `factor` for this field is wrong.

2. **Fan mode shows raw values.** These AC models use a numeric wind
   strength range (2-6) plus a `wind_strength_chaos_swing` enum value,
   instead of the `wind_strength_auto/low/mid/high` scheme the existing
   translations cover. The fan_mode dropdown showed literal untranslated
   strings (`2`, `3`, `4`, `5`, `6`, `wind_strength_chaos_swing`).

## Changes

- `appliance_controls.py`: added a small `KNOWN_BAD_FACTORS` override
  table, applied in `build_read_control_from_feature`, to correct the
  `AIR_CONDITIONER_INSTANT_CONSUMPTION` factor to `0.1` since we can't fix
  Arcelik's server-side CONFIGURATION data.
- `sensor.py`:
  - `NumericControl`-based sensors now read `native_unit_of_measurement`
    from the CONFIGURATION JSON's `boundedValues.unit`, mapping the
    non-standard `"hw"` label to `"kW"` with `device_class: power`.
  - New `HomeWhizEnergyEntity`: for every sensor with a `"hw"` unit, adds a
    companion sensor that trapezoidally integrates the instantaneous kW
    value into a persisted kWh total (`RestoreEntity` +
    `state_class: total_increasing`), so it can be added directly to the
    HA Energy dashboard. Only appliances that actually expose a
    `"hw"`-unit field get this extra entity - verified this doesn't touch
    any other appliance type.
- `translations/*.json`: added the missing numeric fan speed (`2`-`6` →
  `1`-`5`, matching what the AC's own remote displays) and
  `wind_strength_chaos_swing` translations for `tr` (`"Otomatik"`, per the
  Turkish manual) and `en`/`de`/`ru`/`sk` (`"Chaos Swing"`, matching the
  appliance's own user manual wording in those languages). Other language
  files didn't have a `fan_mode` block at all before this PR and were left
  untouched rather than guessing translations.

## Testing

Tested live against Arcelik Ekolojik 18325 and 15325 AC units over
MQTT/cloud. Confirmed:
- Fan mode dropdown now shows `1`-`5` + `Otomatik`/`Chaos Swing` instead of
  raw values.
- Instant consumption sensor now shows `kW` with correct-order-of-magnitude
  values, matching the appliance's own remote display and user manual.
- New `_total` energy sensor accumulates kWh correctly and survives HA
  restarts, successfully added to the Energy dashboard.