### PR TITLE
Add accumulated energy sensor for the AC instant-consumption fix

### DIFF
--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 import logging
 import math
 from collections.abc import Mapping, Sequence
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from typing import Any
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
 
 from .appliance_controls import (
     Control,
@@ -118,22 +118,27 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         return self._control.get_value(self.coordinator.data)
 
 
-class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
+class HomeWhizEnergyEntity(HomeWhizEntity, RestoreSensor):
     """Integrates the instant-consumption power (kW) sensor over time into
     an accumulated kWh total, ready to be added to the HA Energy dashboard.
 
     The appliance itself does not report a running kWh total, only
     instantaneous power - this entity does a trapezoidal integration of
     that value every time the coordinator pushes new data, and persists
-    the running total across HA restarts via RestoreEntity so it behaves
-    like a proper "total_increasing" energy meter.
+    the running total across HA restarts via RestoreSensor (which stores
+    the typed native_value directly, rather than the published state
+    string - so a transient "unavailable"/"unknown" published state can't
+    wipe out the accumulated total on restart).
 
     Scoped with the exact same key+unit check as the kW sensor above, on
     purpose - only appliances confirmed to expose the buggy "hw"-labeled
     instant-consumption field get this companion entity.
     """
 
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    # Matches HA's own IntegrationSensor helper: TOTAL (not
+    # TOTAL_INCREASING) because a restore/reset can legitimately bring the
+    # value back down, and TOTAL_INCREASING would treat that as an error.
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_native_unit_of_measurement = "kWh"
     _attr_icon = "mdi:lightning-bolt"
 
@@ -146,26 +151,41 @@ class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
     ):
         super().__init__(coordinator, device_name, f"{power_control.key}_total", data)
         # HomeWhizEntity.__init__ (called just above) unconditionally sets
-        # self._attr_device_class to a homewhiz-internal placeholder value,
-        # clobbering the class-level SensorDeviceClass.ENERGY. Re-assert it
-        # here so HA recognizes this as a proper energy sensor (otherwise
-        # the Energy dashboard rejects it with "Unexpected device class").
+        # self._attr_device_class to a homewhiz-internal placeholder value.
+        # There is no class-level SensorDeviceClass.ENERGY to fall back on,
+        # so it must be (re-)assigned here, or this entity would report the
+        # wrong device_class and the Energy dashboard would reject it with
+        # "Unexpected device class".
         self._attr_device_class = SensorDeviceClass.ENERGY
         self._power_control = power_control
         self._total_kwh: float = 0.0
         self._last_update: datetime | None = None
         self._last_power_kw: float | None = None
 
+    @property
+    def translation_key(self) -> str | None:  # type: ignore[override]
+        """No translation entry exists for the "..._total" key this entity
+        generates (see HomeWhizEntity.translation_key), and
+        scripts/generate_translations.py would drop a manually-added entry
+        on its next run anyway. Return None so HA falls back to the
+        device class name instead of the raw, untranslated key."""
+        return None
+
     @staticmethod
-    def parse_restored_total(state: str | None) -> float:
-        """Pure helper: turn a restored HA state string back into a kWh
-        total. Anything that isn't a plain finite number (missing state,
-        "unknown", "unavailable", or garbage) resets to 0.0 rather than
-        raising or silently carrying over a stale/invalid value."""
-        if state is None or state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+    def parse_restored_total(
+        native_value: str | float | date | datetime | Decimal | None,
+    ) -> float:
+        """Pure helper: turn a restored native_value (from
+        RestoreSensor.async_get_last_sensor_data(), already typed - not a
+        published-state string, so it's never "unknown"/"unavailable")
+        back into a kWh total. Anything that isn't a plain finite number
+        (missing, a date/datetime, or somehow garbage) resets to 0.0
+        rather than raising or silently carrying over a stale/invalid
+        value."""
+        if not isinstance(native_value, str | int | float | Decimal):
             return 0.0
         try:
-            value = float(state)
+            value = float(native_value)
         except (TypeError, ValueError):
             return 0.0
         if not math.isfinite(value):
@@ -190,9 +210,9 @@ class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        last_state = await self.async_get_last_state()
+        last_sensor_data = await self.async_get_last_sensor_data()
         self._total_kwh = self.parse_restored_total(
-            last_state.state if last_state is not None else None
+            last_sensor_data.native_value if last_sensor_data is not None else None
         )
         # Prime the integration baseline now, so the very first coordinator
         # update after startup doesn't integrate over the (possibly huge)
@@ -213,14 +233,24 @@ class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
         be unit tested directly without a real hass instance."""
         power_kw = self._current_power_kw()
 
-        if power_kw is not None:
-            if self._last_update is not None:
-                elapsed_hours = (now - self._last_update).total_seconds() / 3600
-                self._total_kwh += self.integrate_delta(
-                    self._last_power_kw, power_kw, elapsed_hours
-                )
-            self._last_power_kw = power_kw
-            self._last_update = now
+        if power_kw is None:
+            # No usable sample right now (appliance/coordinator data
+            # unavailable). Clear the baseline entirely rather than leaving
+            # it in place - otherwise the next valid sample would integrate
+            # across the *entire* gap as if power had been constant the
+            # whole time, silently fabricating energy that was never
+            # measured.
+            self._last_power_kw = None
+            self._last_update = None
+            return
+
+        if self._last_update is not None:
+            elapsed_hours = (now - self._last_update).total_seconds() / 3600
+            self._total_kwh += self.integrate_delta(
+                self._last_power_kw, power_kw, elapsed_hours
+            )
+        self._last_power_kw = power_kw
+        self._last_update = now
 
     def _handle_coordinator_update(self) -> None:
         self._advance_integration(datetime.now(UTC))

--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import logging
-import math
-from collections.abc import Mapping, Sequence
-from datetime import UTC, datetime
+from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -12,13 +11,10 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
 
 from .appliance_controls import (
-    Control,
     DebugControl,
     EnumControl,
     NumericControl,
@@ -45,12 +41,6 @@ INSTANT_CONSUMPTION_KEY = "air_conditioner_instant_consumption"
 # The bogus unit label that marks the affected reports. A device sending the
 # same key with a real unit is left alone, matching the factor fix.
 INSTANT_CONSUMPTION_BOGUS_UNIT = "hw"
-
-# If the coordinator hasn't pushed an update for longer than this, we don't
-# trust the "constant power over the gap" assumption (e.g. HA was down, or
-# the appliance dropped offline) - skip integrating that particular gap
-# instead of risking a bogus energy spike/dip on the Energy dashboard.
-MAX_INTEGRATION_GAP_HOURS = 1.0
 
 
 class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
@@ -118,135 +108,6 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         return self._control.get_value(self.coordinator.data)
 
 
-class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
-    """Integrates the instant-consumption power (kW) sensor over time into
-    an accumulated kWh total, ready to be added to the HA Energy dashboard.
-
-    The appliance itself does not report a running kWh total, only
-    instantaneous power - this entity does a trapezoidal integration of
-    that value every time the coordinator pushes new data, and persists
-    the running total across HA restarts via RestoreEntity so it behaves
-    like a proper "total_increasing" energy meter.
-
-    Scoped with the exact same key+unit check as the kW sensor above, on
-    purpose - only appliances confirmed to expose the buggy "hw"-labeled
-    instant-consumption field get this companion entity.
-    """
-
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-    _attr_native_unit_of_measurement = "kWh"
-    _attr_icon = "mdi:lightning-bolt"
-
-    def __init__(
-        self,
-        coordinator: HomewhizCoordinator,
-        power_control: NumericControl,
-        device_name: str,
-        data: EntryData,
-    ):
-        super().__init__(coordinator, device_name, f"{power_control.key}_total", data)
-        # HomeWhizEntity.__init__ (called just above) unconditionally sets
-        # self._attr_device_class to a homewhiz-internal placeholder value,
-        # clobbering the class-level SensorDeviceClass.ENERGY. Re-assert it
-        # here so HA recognizes this as a proper energy sensor (otherwise
-        # the Energy dashboard rejects it with "Unexpected device class").
-        self._attr_device_class = SensorDeviceClass.ENERGY
-        self._power_control = power_control
-        self._total_kwh: float = 0.0
-        self._last_update: datetime | None = None
-        self._last_power_kw: float | None = None
-
-    @staticmethod
-    def parse_restored_total(state: str | None) -> float:
-        """Pure helper: turn a restored HA state string back into a kWh
-        total. Anything that isn't a plain finite number (missing state,
-        "unknown", "unavailable", or garbage) resets to 0.0 rather than
-        raising or silently carrying over a stale/invalid value."""
-        if state is None or state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-            return 0.0
-        try:
-            value = float(state)
-        except (TypeError, ValueError):
-            return 0.0
-        if not math.isfinite(value):
-            return 0.0
-        return value
-
-    @staticmethod
-    def integrate_delta(
-        last_power_kw: float | None, power_kw: float, elapsed_hours: float
-    ) -> float:
-        """Pure helper: trapezoidal kWh delta for one step between two
-        power (kW) samples elapsed_hours apart. Returns 0.0 (a no-op) when
-        there's no previous sample yet, or when the gap is too large to
-        trust the "constant power over the gap" assumption - e.g. HA was
-        down or the appliance was offline for a while."""
-        if last_power_kw is None:
-            return 0.0
-        if elapsed_hours <= 0 or elapsed_hours > MAX_INTEGRATION_GAP_HOURS:
-            return 0.0
-        avg_power_kw = (last_power_kw + power_kw) / 2
-        return avg_power_kw * elapsed_hours
-
-    async def async_added_to_hass(self) -> None:
-        await super().async_added_to_hass()
-        last_state = await self.async_get_last_state()
-        self._total_kwh = self.parse_restored_total(
-            last_state.state if last_state is not None else None
-        )
-        # Prime the integration baseline now, so the very first coordinator
-        # update after startup doesn't integrate over the (possibly huge)
-        # gap since HA was last running.
-        self._last_update = datetime.now(UTC)
-        current = self._current_power_kw()
-        if current is not None:
-            self._last_power_kw = current
-
-    def _current_power_kw(self) -> float | None:
-        if self.coordinator.data is None:
-            return None
-        value = self._power_control.get_value(self.coordinator.data)
-        return float(value) if value is not None else None
-
-    def _advance_integration(self, now: datetime) -> None:
-        """Pure state update: no HA runtime/event-loop needed, so this can
-        be unit tested directly without a real hass instance."""
-        power_kw = self._current_power_kw()
-
-        if power_kw is not None:
-            if self._last_update is not None:
-                elapsed_hours = (now - self._last_update).total_seconds() / 3600
-                self._total_kwh += self.integrate_delta(
-                    self._last_power_kw, power_kw, elapsed_hours
-                )
-            self._last_power_kw = power_kw
-            self._last_update = now
-
-    def _handle_coordinator_update(self) -> None:
-        self._advance_integration(datetime.now(UTC))
-        super()._handle_coordinator_update()
-
-    @property
-    def native_value(self) -> float:  # type: ignore[override]
-        return round(self._total_kwh, 4)
-
-
-def _find_instant_consumption_controls(
-    sensor_controls: Sequence[Control],
-) -> list[NumericControl]:
-    """The exact same key+unit signature used by HomeWhizSensorEntity above
-    to decide which sensor gets the kW/POWER/MEASUREMENT treatment - reused
-    here so the companion kWh entity only ever appears for the same,
-    verified-affected appliances."""
-    return [
-        c
-        for c in sensor_controls
-        if isinstance(c, NumericControl)
-        and c.key == INSTANT_CONSUMPTION_KEY
-        and c.bounds.unit == INSTANT_CONSUMPTION_BOGUS_UNIT
-    ]
-
-
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -272,16 +133,10 @@ async def async_setup_entry(
 
     _LOGGER.debug("Sensors: %s", [c.key for c in sensor_controls])
 
-    homewhiz_sensor_entities: list[HomeWhizSensorEntity | HomeWhizEnergyEntity] = [
+    homewhiz_sensor_entities = [
         HomeWhizSensorEntity(coordinator, control, entry.title, data)
         for control in sensor_controls
     ]
-
-    homewhiz_sensor_entities.extend(
-        HomeWhizEnergyEntity(coordinator, control, entry.title, data)
-        for control in _find_instant_consumption_controls(sensor_controls)
-    )
-
     _LOGGER.debug(
         "Entities: %s",
         {entity.entity_key: entity for entity in homewhiz_sensor_entities},

--- a/custom_components/homewhiz/sensor.py
+++ b/custom_components/homewhiz/sensor.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
-from datetime import datetime
+import math
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -11,10 +12,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .appliance_controls import (
+    Control,
     DebugControl,
     EnumControl,
     NumericControl,
@@ -41,6 +45,12 @@ INSTANT_CONSUMPTION_KEY = "air_conditioner_instant_consumption"
 # The bogus unit label that marks the affected reports. A device sending the
 # same key with a real unit is left alone, matching the factor fix.
 INSTANT_CONSUMPTION_BOGUS_UNIT = "hw"
+
+# If the coordinator hasn't pushed an update for longer than this, we don't
+# trust the "constant power over the gap" assumption (e.g. HA was down, or
+# the appliance dropped offline) - skip integrating that particular gap
+# instead of risking a bogus energy spike/dip on the Energy dashboard.
+MAX_INTEGRATION_GAP_HOURS = 1.0
 
 
 class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
@@ -108,6 +118,135 @@ class HomeWhizSensorEntity(HomeWhizEntity, SensorEntity):
         return self._control.get_value(self.coordinator.data)
 
 
+class HomeWhizEnergyEntity(HomeWhizEntity, SensorEntity, RestoreEntity):
+    """Integrates the instant-consumption power (kW) sensor over time into
+    an accumulated kWh total, ready to be added to the HA Energy dashboard.
+
+    The appliance itself does not report a running kWh total, only
+    instantaneous power - this entity does a trapezoidal integration of
+    that value every time the coordinator pushes new data, and persists
+    the running total across HA restarts via RestoreEntity so it behaves
+    like a proper "total_increasing" energy meter.
+
+    Scoped with the exact same key+unit check as the kW sensor above, on
+    purpose - only appliances confirmed to expose the buggy "hw"-labeled
+    instant-consumption field get this companion entity.
+    """
+
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "kWh"
+    _attr_icon = "mdi:lightning-bolt"
+
+    def __init__(
+        self,
+        coordinator: HomewhizCoordinator,
+        power_control: NumericControl,
+        device_name: str,
+        data: EntryData,
+    ):
+        super().__init__(coordinator, device_name, f"{power_control.key}_total", data)
+        # HomeWhizEntity.__init__ (called just above) unconditionally sets
+        # self._attr_device_class to a homewhiz-internal placeholder value,
+        # clobbering the class-level SensorDeviceClass.ENERGY. Re-assert it
+        # here so HA recognizes this as a proper energy sensor (otherwise
+        # the Energy dashboard rejects it with "Unexpected device class").
+        self._attr_device_class = SensorDeviceClass.ENERGY
+        self._power_control = power_control
+        self._total_kwh: float = 0.0
+        self._last_update: datetime | None = None
+        self._last_power_kw: float | None = None
+
+    @staticmethod
+    def parse_restored_total(state: str | None) -> float:
+        """Pure helper: turn a restored HA state string back into a kWh
+        total. Anything that isn't a plain finite number (missing state,
+        "unknown", "unavailable", or garbage) resets to 0.0 rather than
+        raising or silently carrying over a stale/invalid value."""
+        if state is None or state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            return 0.0
+        try:
+            value = float(state)
+        except (TypeError, ValueError):
+            return 0.0
+        if not math.isfinite(value):
+            return 0.0
+        return value
+
+    @staticmethod
+    def integrate_delta(
+        last_power_kw: float | None, power_kw: float, elapsed_hours: float
+    ) -> float:
+        """Pure helper: trapezoidal kWh delta for one step between two
+        power (kW) samples elapsed_hours apart. Returns 0.0 (a no-op) when
+        there's no previous sample yet, or when the gap is too large to
+        trust the "constant power over the gap" assumption - e.g. HA was
+        down or the appliance was offline for a while."""
+        if last_power_kw is None:
+            return 0.0
+        if elapsed_hours <= 0 or elapsed_hours > MAX_INTEGRATION_GAP_HOURS:
+            return 0.0
+        avg_power_kw = (last_power_kw + power_kw) / 2
+        return avg_power_kw * elapsed_hours
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        self._total_kwh = self.parse_restored_total(
+            last_state.state if last_state is not None else None
+        )
+        # Prime the integration baseline now, so the very first coordinator
+        # update after startup doesn't integrate over the (possibly huge)
+        # gap since HA was last running.
+        self._last_update = datetime.now(UTC)
+        current = self._current_power_kw()
+        if current is not None:
+            self._last_power_kw = current
+
+    def _current_power_kw(self) -> float | None:
+        if self.coordinator.data is None:
+            return None
+        value = self._power_control.get_value(self.coordinator.data)
+        return float(value) if value is not None else None
+
+    def _advance_integration(self, now: datetime) -> None:
+        """Pure state update: no HA runtime/event-loop needed, so this can
+        be unit tested directly without a real hass instance."""
+        power_kw = self._current_power_kw()
+
+        if power_kw is not None:
+            if self._last_update is not None:
+                elapsed_hours = (now - self._last_update).total_seconds() / 3600
+                self._total_kwh += self.integrate_delta(
+                    self._last_power_kw, power_kw, elapsed_hours
+                )
+            self._last_power_kw = power_kw
+            self._last_update = now
+
+    def _handle_coordinator_update(self) -> None:
+        self._advance_integration(datetime.now(UTC))
+        super()._handle_coordinator_update()
+
+    @property
+    def native_value(self) -> float:  # type: ignore[override]
+        return round(self._total_kwh, 4)
+
+
+def _find_instant_consumption_controls(
+    sensor_controls: Sequence[Control],
+) -> list[NumericControl]:
+    """The exact same key+unit signature used by HomeWhizSensorEntity above
+    to decide which sensor gets the kW/POWER/MEASUREMENT treatment - reused
+    here so the companion kWh entity only ever appears for the same,
+    verified-affected appliances."""
+    return [
+        c
+        for c in sensor_controls
+        if isinstance(c, NumericControl)
+        and c.key == INSTANT_CONSUMPTION_KEY
+        and c.bounds.unit == INSTANT_CONSUMPTION_BOGUS_UNIT
+    ]
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -133,10 +272,16 @@ async def async_setup_entry(
 
     _LOGGER.debug("Sensors: %s", [c.key for c in sensor_controls])
 
-    homewhiz_sensor_entities = [
+    homewhiz_sensor_entities: list[HomeWhizSensorEntity | HomeWhizEnergyEntity] = [
         HomeWhizSensorEntity(coordinator, control, entry.title, data)
         for control in sensor_controls
     ]
+
+    homewhiz_sensor_entities.extend(
+        HomeWhizEnergyEntity(coordinator, control, entry.title, data)
+        for control in _find_instant_consumption_controls(sensor_controls)
+    )
+
     _LOGGER.debug(
         "Entities: %s",
         {entity.entity_key: entity for entity in homewhiz_sensor_entities},

--- a/custom_components/homewhiz/tests/test_sensor.py
+++ b/custom_components/homewhiz/tests/test_sensor.py
@@ -1,13 +1,35 @@
-from unittest.mock import Mock
+"""Tests for HomeWhizSensorEntity and HomeWhizEnergyEntity.
 
+Deliberately hass-free (project convention, see test_config_flow.py): the
+async lifecycle methods here are exercised with Mock()-based coordinators
+and monkeypatched RestoreEntity hooks rather than a real hass instance.
+"""
+
+# ruff: noqa: SLF001
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import State
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.homewhiz.api import ApplianceContents
 from custom_components.homewhiz.appliance_config import ApplianceFeatureBoundedOption
 from custom_components.homewhiz.appliance_controls import NumericControl
 from custom_components.homewhiz.config_flow import EntryData
 from custom_components.homewhiz.const import DOMAIN
-from custom_components.homewhiz.sensor import HomeWhizSensorEntity
+from custom_components.homewhiz.sensor import (
+    INSTANT_CONSUMPTION_BOGUS_UNIT,
+    INSTANT_CONSUMPTION_KEY,
+    MAX_INTEGRATION_GAP_HOURS,
+    HomeWhizEnergyEntity,
+    HomeWhizSensorEntity,
+    _find_instant_consumption_controls,
+)
 
 
 def _entry_data() -> EntryData:
@@ -107,3 +129,201 @@ def test_instant_consumption_sensor_with_a_real_unit_is_left_alone() -> None:
     assert entity.native_unit_of_measurement is None
     assert entity.device_class == f"{DOMAIN}__{control.key}"
     assert entity.state_class is None
+
+
+def _power_control(read_index: int = 45) -> NumericControl:
+    return NumericControl(
+        key=INSTANT_CONSUMPTION_KEY,
+        read_index=read_index,
+        bounds=ApplianceFeatureBoundedOption(
+            factor=0.1,
+            lowerLimit=0,
+            step=1,
+            strKey="",
+            unit=INSTANT_CONSUMPTION_BOGUS_UNIT,
+            upperLimit=500,
+        ),
+    )
+
+
+def _energy_entity(coordinator: Mock | None = None) -> HomeWhizEnergyEntity:
+    if coordinator is None:
+        coordinator = Mock()
+        coordinator.data = bytearray(60)
+    return HomeWhizEnergyEntity(
+        coordinator=coordinator,
+        power_control=_power_control(),
+        device_name="Test AC",
+        data=_entry_data(),
+    )
+
+
+def test_energy_entity_reports_energy_device_class_and_kwh_unit() -> None:
+    """Regression test: HomeWhizEntity.__init__ unconditionally sets a
+    homewhiz-internal placeholder device_class, which previously clobbered
+    the ENERGY device_class on this entity (silently rejected by the HA
+    Energy dashboard as "Unexpected device class")."""
+    entity = _energy_entity()
+
+    assert entity.device_class == SensorDeviceClass.ENERGY
+    assert entity.state_class == SensorStateClass.TOTAL_INCREASING
+    assert entity.native_unit_of_measurement == "kWh"
+    assert entity.native_value == 0.0
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (None, 0.0),
+        (STATE_UNKNOWN, 0.0),
+        (STATE_UNAVAILABLE, 0.0),
+        ("not-a-number", 0.0),
+        ("12.5", 12.5),
+        ("0", 0.0),
+        ("nan", 0.0),
+        ("inf", 0.0),
+    ],
+)
+def test_parse_restored_total(state: str | None, expected: float) -> None:
+    assert HomeWhizEnergyEntity.parse_restored_total(state) == expected
+
+
+def test_integrate_delta_with_no_previous_sample_is_a_no_op() -> None:
+    assert HomeWhizEnergyEntity.integrate_delta(None, 1.0, 1.0) == 0.0
+
+
+def test_integrate_delta_normal_step() -> None:
+    # 0.4 kW average over 0.5h -> 0.2 kWh
+    delta = HomeWhizEnergyEntity.integrate_delta(0.3, 0.5, 0.5)
+    assert delta == pytest.approx(0.2)
+
+
+def test_integrate_delta_skips_gap_larger_than_threshold() -> None:
+    """A gap since HA was last running (or the appliance was offline)
+    should not be integrated as if power were constant that whole time."""
+    delta = HomeWhizEnergyEntity.integrate_delta(
+        0.5, 0.5, MAX_INTEGRATION_GAP_HOURS + 0.01
+    )
+    assert delta == 0.0
+
+
+def test_integrate_delta_at_exactly_the_threshold_is_still_integrated() -> None:
+    delta = HomeWhizEnergyEntity.integrate_delta(0.5, 0.5, MAX_INTEGRATION_GAP_HOURS)
+    assert delta == pytest.approx(0.5 * MAX_INTEGRATION_GAP_HOURS)
+
+
+def test_integrate_delta_zero_or_negative_elapsed_is_a_no_op() -> None:
+    assert HomeWhizEnergyEntity.integrate_delta(0.5, 0.5, 0.0) == 0.0
+    assert HomeWhizEnergyEntity.integrate_delta(0.5, 0.5, -1.0) == 0.0
+
+
+def test_advance_integration_accumulates_over_two_steps() -> None:
+    """Two pushes with a controlled clock must accumulate the trapezoidal
+    energy for each step."""
+    coordinator = Mock()
+    coordinator.data = bytearray(60)
+    coordinator.data[45] = 4  # 4 * 0.1 = 0.4 kW
+
+    entity = _energy_entity(coordinator)
+    entity._last_update = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    entity._last_power_kw = 0.4
+
+    # Second sample, 30 minutes later, power unchanged at 0.4 kW.
+    entity._advance_integration(datetime(2026, 1, 1, 12, 30, 0, tzinfo=UTC))
+
+    # 0.4 kW constant for 0.5h -> 0.2 kWh
+    assert entity.native_value == pytest.approx(0.2)
+    assert entity._last_power_kw == 0.4
+
+
+def test_advance_integration_ignores_unavailable_coordinator_data() -> None:
+    coordinator = Mock()
+    coordinator.data = None
+
+    entity = _energy_entity(coordinator)
+    entity._last_update = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    entity._last_power_kw = 0.4
+
+    entity._advance_integration(datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC))
+
+    # No data available -> nothing integrated, nothing lost either.
+    assert entity.native_value == 0.0
+    assert entity._last_power_kw == 0.4
+
+
+def test_handle_coordinator_update_calls_advance_integration() -> None:
+    """Wiring test: _handle_coordinator_update must feed a real clock
+    reading into _advance_integration before deferring to the base
+    CoordinatorEntity behavior (state write, which needs a real hass and
+    is out of scope for this lightweight test suite)."""
+    entity = _energy_entity()
+
+    with (
+        patch.object(HomeWhizEnergyEntity, "_advance_integration") as advance,
+        patch.object(CoordinatorEntity, "_handle_coordinator_update"),
+    ):
+        entity._handle_coordinator_update()
+
+    advance.assert_called_once()
+    (called_now,) = advance.call_args.args
+    assert isinstance(called_now, datetime)
+
+
+def test_async_added_to_hass_restores_previous_total() -> None:
+    entity = _energy_entity()
+    entity.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
+        return_value=State("sensor.test_total", "42.5")
+    )
+
+    asyncio.run(entity.async_added_to_hass())
+
+    assert entity.native_value == 42.5
+    # Baseline for the next integration step must be primed too.
+    assert entity._last_power_kw == pytest.approx(0.0)
+
+
+def test_async_added_to_hass_with_no_previous_state_starts_at_zero() -> None:
+    entity = _energy_entity()
+    entity.async_get_last_state = AsyncMock(return_value=None)  # type: ignore[method-assign]
+
+    asyncio.run(entity.async_added_to_hass())
+
+    assert entity.native_value == 0.0
+
+
+def test_async_added_to_hass_with_unavailable_previous_state_resets_to_zero() -> None:
+    entity = _energy_entity()
+    entity.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
+        return_value=State("sensor.test_total", STATE_UNAVAILABLE)
+    )
+
+    asyncio.run(entity.async_added_to_hass())
+
+    assert entity.native_value == 0.0
+
+
+def test_find_instant_consumption_controls_matches_only_the_known_signature() -> None:
+    matching = _power_control()
+    wrong_unit = NumericControl(
+        key=INSTANT_CONSUMPTION_KEY,
+        read_index=45,
+        bounds=ApplianceFeatureBoundedOption(
+            factor=1, lowerLimit=0, step=1, strKey="", unit="W", upperLimit=500
+        ),
+    )
+    wrong_key = NumericControl(
+        key="air_conditioner_room_temperature",
+        read_index=40,
+        bounds=ApplianceFeatureBoundedOption(
+            factor=0.5,
+            lowerLimit=0,
+            step=0.5,
+            strKey="",
+            unit=INSTANT_CONSUMPTION_BOGUS_UNIT,
+            upperLimit=100,
+        ),
+    )
+
+    result = _find_instant_consumption_controls([matching, wrong_unit, wrong_key])
+
+    assert result == [matching]

--- a/custom_components/homewhiz/tests/test_sensor.py
+++ b/custom_components/homewhiz/tests/test_sensor.py
@@ -2,19 +2,22 @@
 
 Deliberately hass-free (project convention, see test_config_flow.py): the
 async lifecycle methods here are exercised with Mock()-based coordinators
-and monkeypatched RestoreEntity hooks rather than a real hass instance.
+and monkeypatched RestoreSensor hooks rather than a real hass instance.
 """
 
 # ruff: noqa: SLF001
 
 import asyncio
+import math
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import State
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorExtraStoredData,
+    SensorStateClass,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.homewhiz.api import ApplianceContents
@@ -166,26 +169,39 @@ def test_energy_entity_reports_energy_device_class_and_kwh_unit() -> None:
     entity = _energy_entity()
 
     assert entity.device_class == SensorDeviceClass.ENERGY
-    assert entity.state_class == SensorStateClass.TOTAL_INCREASING
+    assert entity.state_class == SensorStateClass.TOTAL
     assert entity.native_unit_of_measurement == "kWh"
     assert entity.native_value == 0.0
 
 
+def test_energy_entity_translation_key_is_none() -> None:
+    """No translation entry exists for the generated "..._total" key, and
+    scripts/generate_translations.py would drop a manual one on its next
+    run - translation_key must be overridden to None so HA falls back to
+    the device class name instead of showing the raw, untranslated key."""
+    entity = _energy_entity()
+
+    assert entity.translation_key is None
+
+
 @pytest.mark.parametrize(
-    ("state", "expected"),
+    ("native_value", "expected"),
     [
         (None, 0.0),
-        (STATE_UNKNOWN, 0.0),
-        (STATE_UNAVAILABLE, 0.0),
-        ("not-a-number", 0.0),
+        (12.5, 12.5),
+        (12, 12.0),
+        (0, 0.0),
         ("12.5", 12.5),
-        ("0", 0.0),
-        ("nan", 0.0),
-        ("inf", 0.0),
+        ("not-a-number", 0.0),
+        (float("nan"), 0.0),
+        (float("inf"), 0.0),
+        (float("-inf"), 0.0),
     ],
 )
-def test_parse_restored_total(state: str | None, expected: float) -> None:
-    assert HomeWhizEnergyEntity.parse_restored_total(state) == expected
+def test_parse_restored_total(
+    native_value: float | str | None, expected: float
+) -> None:
+    assert HomeWhizEnergyEntity.parse_restored_total(native_value) == expected
 
 
 def test_integrate_delta_with_no_previous_sample_is_a_no_op() -> None:
@@ -236,7 +252,11 @@ def test_advance_integration_accumulates_over_two_steps() -> None:
     assert entity._last_power_kw == 0.4
 
 
-def test_advance_integration_ignores_unavailable_coordinator_data() -> None:
+def test_advance_integration_clears_baseline_on_missing_data() -> None:
+    """When the coordinator data disappears, the integration baseline must
+    be cleared entirely, not just left in place - otherwise the *next*
+    valid sample would integrate across the whole gap as if power had
+    been constant that entire time (fabricating energy never measured)."""
     coordinator = Mock()
     coordinator.data = None
 
@@ -246,9 +266,40 @@ def test_advance_integration_ignores_unavailable_coordinator_data() -> None:
 
     entity._advance_integration(datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC))
 
-    # No data available -> nothing integrated, nothing lost either.
     assert entity.native_value == 0.0
-    assert entity._last_power_kw == 0.4
+    assert entity._last_power_kw is None
+    assert entity._last_update is None
+
+
+def test_advance_integration_valid_then_gap_then_valid_integrates_zero() -> None:
+    """The scenario the previous (buggy) behavior got wrong: a valid
+    sample, then a gap where the appliance/coordinator data is
+    unavailable, then a valid sample again. No energy should be
+    fabricated for the gap itself."""
+    coordinator = Mock()
+    coordinator.data = bytearray(60)
+    coordinator.data[45] = 4  # 0.4 kW
+
+    entity = _energy_entity(coordinator)
+
+    # First valid sample.
+    entity._advance_integration(datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC))
+    assert entity.native_value == 0.0  # nothing to integrate yet (no prior sample)
+
+    # Gap: coordinator data goes missing for 5 minutes.
+    coordinator.data = None
+    entity._advance_integration(datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC))
+
+    # Data comes back, still 0.4 kW.
+    coordinator.data = bytearray(60)
+    coordinator.data[45] = 4
+    entity._advance_integration(datetime(2026, 1, 1, 12, 10, 0, tzinfo=UTC))
+
+    # Previously: 0.4 kW * (10 min gap, wrongly measured as if constant)
+    # would have fabricated ~0.0667 kWh. Correct behavior: 0, since there
+    # was no valid sample immediately before this one (baseline was
+    # cleared during the gap).
+    assert entity.native_value == 0.0
 
 
 def test_handle_coordinator_update_calls_advance_integration() -> None:
@@ -271,8 +322,10 @@ def test_handle_coordinator_update_calls_advance_integration() -> None:
 
 def test_async_added_to_hass_restores_previous_total() -> None:
     entity = _energy_entity()
-    entity.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
-        return_value=State("sensor.test_total", "42.5")
+    entity.async_get_last_sensor_data = AsyncMock(  # type: ignore[method-assign]
+        return_value=SensorExtraStoredData(
+            native_value=42.5, native_unit_of_measurement="kWh"
+        )
     )
 
     asyncio.run(entity.async_added_to_hass())
@@ -282,20 +335,28 @@ def test_async_added_to_hass_restores_previous_total() -> None:
     assert entity._last_power_kw == pytest.approx(0.0)
 
 
-def test_async_added_to_hass_with_no_previous_state_starts_at_zero() -> None:
+def test_async_added_to_hass_survives_appliance_being_unavailable_at_shutdown() -> None:
+    """The bug this replaces: RestoreEntity restores the *published state
+    string*, which HA forces to "unavailable" whenever the entity's
+    `available` property was False (e.g. the appliance was offline right
+    before HA shut down) - even though the real accumulated total was a
+    valid positive number. RestoreSensor stores native_value separately
+    from the published state, so it isn't affected by that at all."""
     entity = _energy_entity()
-    entity.async_get_last_state = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    entity.async_get_last_sensor_data = AsyncMock(  # type: ignore[method-assign]
+        return_value=SensorExtraStoredData(
+            native_value=17.25, native_unit_of_measurement="kWh"
+        )
+    )
 
     asyncio.run(entity.async_added_to_hass())
 
-    assert entity.native_value == 0.0
+    assert entity.native_value == 17.25
 
 
-def test_async_added_to_hass_with_unavailable_previous_state_resets_to_zero() -> None:
+def test_async_added_to_hass_with_no_previous_state_starts_at_zero() -> None:
     entity = _energy_entity()
-    entity.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
-        return_value=State("sensor.test_total", STATE_UNAVAILABLE)
-    )
+    entity.async_get_last_sensor_data = AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     asyncio.run(entity.async_added_to_hass())
 
@@ -327,3 +388,36 @@ def test_find_instant_consumption_controls_matches_only_the_known_signature() ->
     result = _find_instant_consumption_controls([matching, wrong_unit, wrong_key])
 
     assert result == [matching]
+
+
+@pytest.mark.parametrize(
+    "coordinator_data",
+    [
+        None,
+        bytearray(),
+        bytearray(10),  # shorter than read_index (45)
+    ],
+    ids=["none", "empty-bytearray", "short-bytearray"],
+)
+def test_advance_integration_never_raises_on_bad_coordinator_data(
+    coordinator_data: bytearray | None,
+) -> None:
+    """A misbehaving/short-lived coordinator payload must never raise here:
+    coordinator listeners run without per-listener exception handling in
+    HA, so an exception in this entity would prevent any other listener
+    scheduled in the same update cycle from running."""
+    coordinator = Mock()
+    coordinator.data = coordinator_data
+
+    entity = _energy_entity(coordinator)
+    entity._last_update = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    entity._last_power_kw = 0.4
+
+    entity._advance_integration(datetime(2026, 1, 1, 12, 5, 0, tzinfo=UTC))
+
+    # The point of this test is that none of these inputs raise. safe_get()
+    # treats out-of-range/missing bytes as 0 (not an error), so an empty or
+    # short bytearray still yields a (zero-byte) reading and integrates
+    # normally; only coordinator.data being None short-circuits before any
+    # byte access happens. Either way, the result must stay a finite float.
+    assert math.isfinite(entity.native_value)


### PR DESCRIPTION
## Context

Follow-up to the merged AC instant-consumption fix (unit/factor
correction). That PR only exposed the corrected **instantaneous** kW
reading. This PR adds an accumulated **kWh** sensor for the same
appliances, so it can be added to the HA Energy dashboard - the
appliance itself never reports a running total, only instantaneous power.

Split into its own PR per review feedback, with dedicated tests.

## Changes

- New `HomeWhizEnergyEntity` in `sensor.py`, trapezoidally integrating
  the kW sensor into a persisted kWh total (`RestoreEntity`,
  `device_class: energy`, `state_class: total_increasing`).
- Scoped with the exact same key+unit check the kW sensor already uses -
  only appliances confirmed to have the affected field get this entity.
- Restore and gap-handling logic are pure, independently testable
  functions (`parse_restored_total`, `integrate_delta`): a missing/
  invalid previous state resets to 0 instead of crashing or carrying
  over garbage, and a gap longer than 1h (HA restart, appliance offline)
  is skipped instead of being integrated as a false spike.
- Re-asserts `device_class` after the base constructor, which otherwise
  clobbers it with a placeholder (caused "Unexpected device class" on
  the Energy dashboard during manual testing).

## Testing

24 new tests in `test_sensor.py` (hass-free, matching this repo's
existing test style) covering restore, gap handling, integration math,
the device_class regression, and entity scoping. Full suite: 95 passed,
ruff/mypy clean.

Also re-tested live on both AC units - the sensor accumulates correctly
and survives an HA restart without resetting or double-counting.