### PR TITLE
Clean up leftovers from unloaded entries

### DIFF
--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -88,7 +88,9 @@ async def setup_bluetooth(
         hass.create_task(coordinator.kill())
 
     _LOGGER.debug("Setting up shutdown event listener")
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, disconnect_service)
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, disconnect_service)
+    )
 
     return True
 

--- a/custom_components/homewhiz/__init__.py
+++ b/custom_components/homewhiz/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.requirements import RequirementsNotFound
 from homeassistant.util.package import install_package, is_installed
 
 from .api import IdExchangeResponse
+from .appliance_controls import forget_controls
 from .bluetooth import HomewhizBluetoothUpdateCoordinator
 from .cloud import HomewhizCloudUpdateCoordinator
 from .config_flow import CloudConfig
@@ -125,4 +126,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.data[DOMAIN][entry.entry_id].kill()
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        forget_controls(entry.entry_id)
     return unload_ok

--- a/custom_components/homewhiz/appliance_controls.py
+++ b/custom_components/homewhiz/appliance_controls.py
@@ -1206,6 +1206,10 @@ def extract_ac_control(control_list: list[Control]) -> list[Control]:
 controls: dict[str, list[Control]] = {}
 
 
+def forget_controls(key: str) -> None:
+    controls.pop(key, None)
+
+
 def generate_controls_from_config(
     key: str,
     config: ApplianceConfiguration,

--- a/custom_components/homewhiz/tests/test_controls.py
+++ b/custom_components/homewhiz/tests/test_controls.py
@@ -14,6 +14,8 @@ from custom_components.homewhiz.appliance_controls import (
     WriteEnumControl,
     WriteTimeControl,
     build_control_from_program,
+    controls,
+    forget_controls,
     generate_controls_from_config,
     get_bounded_values_options,
     to_friendly_name,
@@ -142,3 +144,22 @@ def test_zero_factor_is_skipped() -> None:
 )
 def test_to_friendly_name(raw: str, expected: str) -> None:
     assert to_friendly_name(raw) == expected
+
+
+def test_forget_controls_removes_the_cached_entry(
+    config: ApplianceConfiguration,
+) -> None:
+    key = "test-entry-forget-controls"
+    first = generate_controls_from_config(key, config)
+    assert key in controls
+
+    forget_controls(key)
+
+    assert key not in controls
+    # A rebuilt list, not the same cached object handed back again.
+    assert generate_controls_from_config(key, config) is not first
+    forget_controls(key)  # do not leak state into other tests
+
+
+def test_forget_controls_on_unknown_key_is_a_no_op() -> None:
+    forget_controls("never-generated")

--- a/custom_components/homewhiz/tests/test_init.py
+++ b/custom_components/homewhiz/tests/test_init.py
@@ -6,12 +6,12 @@ enough.
 """
 
 import asyncio
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
-from custom_components.homewhiz import async_setup_entry
+from custom_components.homewhiz import async_setup_entry, setup_bluetooth
 
 
 def test_missing_ids_raises_home_assistant_error() -> None:
@@ -21,3 +21,31 @@ def test_missing_ids_raises_home_assistant_error() -> None:
 
     with pytest.raises(HomeAssistantError):
         asyncio.run(async_setup_entry(Mock(), entry))
+
+
+@patch("custom_components.homewhiz.HomewhizBluetoothUpdateCoordinator")
+@patch("custom_components.homewhiz.async_register_callback")
+def test_stop_listener_is_registered_for_unload(
+    mock_register_callback: Mock, mock_coordinator_cls: Mock
+) -> None:
+    """A reload without this must not leave an extra listener behind each time."""
+    mock_register_callback.return_value = Mock()
+    mock_coordinator_cls.return_value = Mock()
+
+    hass = Mock()
+    hass.data = {}
+    hass.config_entries.async_forward_entry_setups = AsyncMock()
+    stop_unsub = Mock()
+    hass.bus.async_listen_once = Mock(return_value=stop_unsub)
+
+    entry = Mock()
+    entry.unique_id = "00:11:22:33:44:55"
+    entry.entry_id = "entry1"
+    entry.options.get = Mock(return_value=None)
+    registered_unloads: list = []
+    entry.async_on_unload = Mock(side_effect=registered_unloads.append)
+
+    result = asyncio.run(setup_bluetooth(entry.unique_id, entry, hass))
+
+    assert result is True
+    assert stop_unsub in registered_unloads

--- a/custom_components/homewhiz/tests/test_init.py
+++ b/custom_components/homewhiz/tests/test_init.py
@@ -11,7 +11,12 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
-from custom_components.homewhiz import async_setup_entry, setup_bluetooth
+from custom_components.homewhiz import (
+    async_setup_entry,
+    async_unload_entry,
+    setup_bluetooth,
+)
+from custom_components.homewhiz.const import DOMAIN
 
 
 def test_missing_ids_raises_home_assistant_error() -> None:
@@ -49,3 +54,42 @@ def test_stop_listener_is_registered_for_unload(
 
     assert result is True
     assert stop_unsub in registered_unloads
+
+
+@patch("custom_components.homewhiz.forget_controls")
+def test_unload_entry_forgets_cached_controls(mock_forget_controls: Mock) -> None:
+    """The controls cache must not accumulate one stale entry per reload."""
+    coordinator = Mock()
+    coordinator.kill = AsyncMock()
+    hass = Mock()
+    hass.data = {DOMAIN: {"entry1": coordinator}}
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    entry = Mock()
+    entry.unique_id = "test"
+    entry.entry_id = "entry1"
+
+    result = asyncio.run(async_unload_entry(hass, entry))
+
+    assert result is True
+    mock_forget_controls.assert_called_once_with("entry1")
+
+
+@patch("custom_components.homewhiz.forget_controls")
+def test_unload_entry_keeps_cache_when_platform_unload_fails(
+    mock_forget_controls: Mock,
+) -> None:
+    coordinator = Mock()
+    coordinator.kill = AsyncMock()
+    hass = Mock()
+    hass.data = {DOMAIN: {"entry1": coordinator}}
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+
+    entry = Mock()
+    entry.unique_id = "test"
+    entry.entry_id = "entry1"
+
+    result = asyncio.run(async_unload_entry(hass, entry))
+
+    assert result is False
+    mock_forget_controls.assert_not_called()


### PR DESCRIPTION
Two small unload-lifecycle cleanups, grouped in one PR since both touch `__init__.py`.

- The Bluetooth shutdown listener was registered directly on the event bus instead of through the entry's unload hook, so every reload left another listener behind holding a reference to the dead coordinator until the next Home Assistant restart.
- The cached control list for an entry was never dropped on unload, so removing a device left its controls in memory for the process lifetime.