### PR TITLE
Ship the release zip as the HACS download artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Create homewhiz.zip
-      run: cd custom_components && zip -r ../homewhiz.zip homewhiz/
+      run: cd custom_components/homewhiz && zip -r ../../homewhiz.zip .
     - name: Upload homewhiz.zip to release
       uses: softprops/action-gh-release@v3
       with:

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,8 @@
 {
   "name": "HomeWhiz",
   "render_readme": true,
+  "zip_release": true,
+  "filename": "homewhiz.zip",
   "hacs": "1.6.0",
   "homeassistant": "0.118.0"
 }


### PR DESCRIPTION
HACS installs and updates currently pull the source tree file by file, so the `homewhiz.zip`
attached to each release only ever counts stray manual downloads. Declaring the zip as the
release artifact makes HACS use it for installs and updates instead.

Both changes are needed together:

- `hacs.json` declares `zip_release` and `filename`, so HACS knows which asset to use.
- The release workflow builds the zip with the integration files at the archive root. HACS
  extracts the archive straight into `config/custom_components/homewhiz`, so a nested
  `homewhiz/` folder inside the zip would install to the wrong place.

HACS reads `hacs.json` from the tag of the newest release, so both changes only take effect
for releases that carry them. Older releases keep installing from the source tree.

No integration runtime code is changed.