### PR TITLE
Test CI against current Home Assistant on Python 3.14

### DIFF
--- a/.github/workflows/pre-commit_ci.yml
+++ b/.github/workflows/pre-commit_ci.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v7
     - uses: actions/setup-python@v7
       with:
-        python-version: 3.13
+        python-version: 3.14
     - run: |
         pip install pre-commit
         pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Set up Python 3.13
+    - name: Set up Python 3.14
       uses: actions/setup-python@v7
       with:
-        python-version: '3.13'
+        python-version: '3.14'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.13
+  python: python3.14
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,5 @@
 pytest
-serial
-pyserial
 bluetooth_auto_recovery
 dbus_fast
 aiousbwatcher
+serialx


### PR DESCRIPTION
requirements_dev.txt lists homeassistant unpinned, so the 3.13 job can only install 2026.2.3. Everything Home Assistant changed since 2026.3 goes untested, and 2026.3 and later require Python >=3.14.2.

The current HA usb layer imports serialx, not pyserial. Without it all 16 test files fail to collect on 3.14; with it, 106 passed. serial and pyserial are unused under 2026.8.1.

The mypy hook pulls homeassistant-stubs unpinned, so python3.13 held it at stubs 2026.2.3. Workflow and default_language_version have to move together; on 3.14 the hook gets stubs 2026.8.1 and all hooks pass.

CI and dev tooling only. HA 2026.2 drops out of test coverage.