### PR TITLE
Allow disabling active cloud polling

### DIFF
--- a/custom_components/homewhiz/cloud.py
+++ b/custom_components/homewhiz/cloud.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import (
 
 from .api import login
 from .config_flow import CloudConfig
-from .const import DOMAIN
+from .const import CONF_CLOUD_POLLING, DOMAIN
 from .homewhiz import Command, HomewhizCoordinator
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -187,17 +187,26 @@ class HomewhizCloudUpdateCoordinator(HomewhizCoordinator):
             )
         )
 
-        if not self._update_timer_task:
-            self._update_timer_task = async_track_time_interval(
-                hass=self.hass,
-                action=lambda _: self.hass.add_job(self.force_read()),
-                interval=timedelta(minutes=1),
-            )
-            _LOGGER.debug("Set hass time interval update")
+        self._start_active_polling()
 
         await self.get_shadow()
 
         return True
+
+    def _start_active_polling(self) -> None:
+        """Start periodic appliance reads when enabled for this entry."""
+        if (
+            not self._entry.options.get(CONF_CLOUD_POLLING, True)
+            or self._update_timer_task
+        ):
+            return
+
+        self._update_timer_task = async_track_time_interval(
+            hass=self.hass,
+            action=lambda _: self.hass.add_job(self.force_read()),
+            interval=timedelta(minutes=1),
+        )
+        _LOGGER.debug("Set HomeWhiz active polling interval")
 
     async def _subscribe_to_topics(self) -> None:
         if self._connection is None:

--- a/custom_components/homewhiz/config_flow.py
+++ b/custom_components/homewhiz/config_flow.py
@@ -33,7 +33,7 @@ from .api import (
     login,
     make_id_exchange_request,
 )
-from .const import CONF_BT_RECONNECT_INTERVAL, DOMAIN
+from .const import CONF_BT_RECONNECT_INTERVAL, CONF_CLOUD_POLLING, DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -276,11 +276,27 @@ class CloudOptionsFlowHandler(OptionsFlow):
     ) -> ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, options=user_input
+            )
+            await self.hass.config_entries.async_reload(self.config_entry.entry_id)
             return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema({}),
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_CLOUD_POLLING,
+                        description={
+                            "suggested_value": self.config_entry.options.get(
+                                CONF_CLOUD_POLLING, True
+                            )
+                        },
+                        default=True,
+                    ): bool,
+                }
+            ),
         )
 
 

--- a/custom_components/homewhiz/const.py
+++ b/custom_components/homewhiz/const.py
@@ -12,4 +12,5 @@ PLATFORMS = [
 ]
 
 # Configuration
+CONF_CLOUD_POLLING = "cloud_polling"
 CONF_BT_RECONNECT_INTERVAL = "bt_reconnect_interval"

--- a/custom_components/homewhiz/strings.json
+++ b/custom_components/homewhiz/strings.json
@@ -24,7 +24,16 @@
     }
   },
   "options": {
-    "step": {},
+    "step": {
+      "init": {
+        "data": {
+          "cloud_polling": "Active cloud polling"
+        },
+        "data_description": {
+          "cloud_polling": "Request fresh appliance data every minute. Disable this if polling wakes the display or causes other unwanted appliance activity."
+        }
+      }
+    },
     "abort": {
       "no_devices": "[%key:common::config_flow::abort::no_devices%]"
     }

--- a/custom_components/homewhiz/tests/test_cloud.py
+++ b/custom_components/homewhiz/tests/test_cloud.py
@@ -1,4 +1,9 @@
-from custom_components.homewhiz.cloud import shadow_payload_to_data
+from unittest.mock import Mock, patch
+
+from custom_components.homewhiz.cloud import (
+    HomewhizCloudUpdateCoordinator,
+    shadow_payload_to_data,
+)
 
 
 def test_real_shadow_update_decodes_wfa() -> None:
@@ -26,3 +31,33 @@ def test_metadata_only_update_is_ignored() -> None:
 def test_no_reported_state_returns_none() -> None:
     assert shadow_payload_to_data('{"state": null}') is None
     assert shadow_payload_to_data("{}") is None
+
+
+def _coordinator(cloud_polling: bool | None) -> HomewhizCloudUpdateCoordinator:
+    hass = Mock()
+    entry = Mock()
+    entry.options = {} if cloud_polling is None else {"cloud_polling": cloud_polling}
+    coordinator = object.__new__(HomewhizCloudUpdateCoordinator)
+    coordinator.hass = hass
+    coordinator._hass = hass  # noqa: SLF001
+    coordinator._entry = entry  # noqa: SLF001
+    coordinator._update_timer_task = None  # noqa: SLF001
+    return coordinator
+
+
+@patch("custom_components.homewhiz.cloud.async_track_time_interval")
+def test_active_polling_is_enabled_by_default(mock_track: Mock) -> None:
+    coordinator = _coordinator(None)
+
+    coordinator._start_active_polling()  # noqa: SLF001
+
+    mock_track.assert_called_once()
+
+
+@patch("custom_components.homewhiz.cloud.async_track_time_interval")
+def test_active_polling_can_be_disabled(mock_track: Mock) -> None:
+    coordinator = _coordinator(False)
+
+    coordinator._start_active_polling()  # noqa: SLF001
+
+    mock_track.assert_not_called()

--- a/custom_components/homewhiz/translations/en.json
+++ b/custom_components/homewhiz/translations/en.json
@@ -1298,7 +1298,11 @@
         "title": "Homewhiz Options",
         "description": "Allows for advanced configuration of the integration.",
         "data": {
-          "bt_reconnect_interval": "Interval at which to reconnect Bluetooth (in hours)"
+          "bt_reconnect_interval": "Interval at which to reconnect Bluetooth (in hours)",
+          "cloud_polling": "Active cloud polling"
+        },
+        "data_description": {
+          "cloud_polling": "Request fresh appliance data every minute. Disable this if polling wakes the display or causes other unwanted appliance activity."
         }
       }
     }


### PR DESCRIPTION
## Summary

- add an `Active cloud polling` option for cloud-connected appliances
- preserve the existing one-minute polling behavior by default
- allow users to disable periodic `fread` requests when they wake a display or cause unwanted appliance activity
- reload the integration after the cloud option changes
- cover both default-enabled and explicitly-disabled behavior

## Background

The cloud coordinator currently sends an active `fread` request every minute. Some air conditioners visibly react to that request by waking or refreshing their display, even though no set-temperature command was sent. Because other appliance types rely on active polling for timely state updates, this keeps the current behavior as the default and makes it configurable per entry.

Initial state retrieval and the read after a Home Assistant command remain unchanged.

## Validation

- `pre-commit run --all-files`
- `pytest` (109 passed)
