### PR TITLE
Fix and complete Spanish washing machine translations

### DIFF
--- a/custom_components/homewhiz/translations/es.json
+++ b/custom_components/homewhiz/translations/es.json
@@ -23,11 +23,11 @@
       "state": {
         "name": "Estado",
         "state": {
-          "device_state_on": "Encendido",
-          "device_state_off": "Apagado",
-          "device_state_running": "En ejecución",
-          "device_state_paused": "En pausa",
-          "device_state_time_delay_active": "Retardo activo",
+          "device_state_on": "Encendida",
+          "device_state_off": "Apagada",
+          "device_state_running": "En marcha",
+          "device_state_paused": "Pausada",
+          "device_state_time_delay_active": "Inicio diferido",
           "device_state_cancelling": "Cancelando",
           "device_state_door_open": "La puerta está abierta.",
           "device_state_settings": "Configuración"
@@ -36,31 +36,31 @@
       "washer_program": {
         "name": "Programa",
         "state": {
-          "program_cottons": "Algodones",
+          "program_cottons": "Algodón",
           "program_eco_40_60": "Eco 40-60",
           "program_synthetics": "Sintéticos",
-          "program_mini_mini14": "Xpress",
-          "program_wool_handwash": "Woollens",
-          "program_delicates": "PROGRAM_DELICATES",
-          "program_spin_pump": "Spin+Drain",
+          "program_mini_mini14": "Rápido 28/14 min",
+          "program_wool_handwash": "Lana / Lavado a mano",
+          "program_delicates": "Delicados",
+          "program_spin_pump": "Centrifugado + vaciado",
           "program_rinsing": "Aclarado",
-          "program_darkwash": "Ropa oscura (vaqueros)",
-          "program_outdoor_sports_goretex": "Deportes",
-          "program_stain": "Sintéticos seco plancha",
+          "program_darkwash": "Prendas oscuras / Jeans",
+          "program_outdoor_sports_goretex": "Ropa exterior / deportiva",
+          "program_stain": "Manchas PRO",
           "program_hygeine": "Higiene+",
-          "program_duvet": "Edredón/plumón",
+          "program_duvet": "Plumíferos",
           "program_shirts": "Camisas",
           "program_drum_clean": "Limpieza del tambor",
-          "program_mix": "Combinado",
+          "program_mix": "Mixtos",
           "program_curtain": "Cortinas",
           "program_lingerie": "Lencería",
-          "program_soft_toys": "Peluches",
-          "program_towel": "Toalla",
+          "program_soft_toys": "Muñecos de peluche",
+          "program_towel": "Toallas",
           "program_cottons_eco": "Algodón Eco",
           "program_dryer_cotton": "Secado de algodón",
           "program_dryer_synthetics": "Secado de sintéticos",
           "program_hygiene_wash_dry": "Higiene + Wash & Dry",
-          "program_4kg_wash_dry": "Lavado y secado de 4 kg",
+          "program_4kg_wash_dry": "Lavado y secado de 4 kg",
           "program_wash_wear": "Wash & Wear",
           "program_dark_wash": "Lavado de ropa oscura",
           "program_outdoor": "Exteriores",
@@ -71,63 +71,86 @@
       "washer_temperature": {
         "name": "Temperatura",
         "state": {
-          "temperature_cold_wash": "Lavado en frío",
+          "temperature_cold_wash": "Fría",
           "temperature_20": "20 °C",
           "temperature_30": "30 °C",
           "temperature_40": "40 °C",
-          "60c": "60C",
-          "90c": "90C"
+          "60c": "60 °C",
+          "90c": "90 °C"
         }
       },
       "washer_spin": {
         "name": "Centrifugado",
         "state": {
           "spin_no_spin": "Sin centrifugado",
-          "600rpm": "600RPM",
-          "800rpm": "800RPM",
-          "1000rpm": "1000RPM",
-          "1200rpm": "1200RPM",
-          "spin_rinse_hold": "Remojo",
-          "spin_600": "600",
-          "spin_800": "800",
-          "spin_1200": "1200",
-          "spin_1400": "1400",
-          "1400rpm": "1400RPM"
+          "600rpm": "600 rpm",
+          "800rpm": "800 rpm",
+          "1000rpm": "1000 rpm",
+          "1200rpm": "1200 rpm",
+          "spin_rinse_hold": "Retención de aclarado",
+          "spin_600": "600 rpm",
+          "spin_800": "800 rpm",
+          "spin_1200": "1200 rpm",
+          "spin_1400": "1400 rpm",
+          "1400rpm": "1400 rpm"
         }
       },
       "washer_fast_plus": {
         "name": "Fast+",
         "state": {
-          "fast_plus_off": "Fast+ desactivado",
+          "fast_plus_off": "Desactivado",
           "fast_plus_on_fast": "Rápido",
           "fast_plus_on_fast_plus": "Fast+"
         }
       },
       "custom_duration_level": {
-        "name": "Nivel de duración personalizado",
+        "name": "Ajuste de duración",
         "state": {
-          "duration_level_0": "DURATION_LEVEL_0",
-          "1": "1",
-          "2": "2",
-          "3": "3",
-          "4": "4",
-          "5": "5",
-          "6": "6",
-          "7": "7",
-          "8": "8",
-          "9": "9",
-          "10": "10",
-          "11": "11"
+          "duration_level_0": "Nivel 0",
+          "1": "Nivel 1",
+          "2": "Nivel 2",
+          "3": "Nivel 3",
+          "4": "Nivel 4",
+          "5": "Nivel 5",
+          "6": "Nivel 6",
+          "7": "Nivel 7",
+          "8": "Nivel 8",
+          "9": "Nivel 9",
+          "10": "Nivel 10",
+          "11": "Nivel 11"
         }
       },
       "washer_extra_rinse_count": {
         "name": "Número de aclarados adicionales"
       },
       "settings_volume": {
-        "name": "Botón de volumen",
+        "name": "Volumen",
         "state": {
           "volume_low": "Bajo",
           "volume_high": "Alto"
+        }
+      },
+      "washer_hidden_anti_crease": {
+        "name": "Antiarrugas+",
+        "state": {
+          "hidden_anti_crease_off_0": "Desactivado",
+          "hidden_anti_crease_on_1": "Activado"
+        }
+      },
+      "settings_detergent_dosing_quantity": {
+        "name": "Cantidad de detergente",
+        "state": {
+          "quantity_low": "Baja",
+          "quantity_medium": "Media",
+          "quantity_high": "Alta"
+        }
+      },
+      "settings_softener_dosing_quantity": {
+        "name": "Cantidad de suavizante",
+        "state": {
+          "quantity_low": "Baja",
+          "quantity_medium": "Media",
+          "quantity_high": "Alta"
         }
       },
       "remote_control": {
@@ -180,10 +203,10 @@
       "program": {
         "name": "Programa",
         "state": {
-          "program_auto": "40-65 °C automático",
+          "program_auto": "40-65 °C automático",
           "program_mix_wash_plus": "All-in-Wash",
-          "program_intensive_70": "Intensivo 70 °C",
-          "program_eco_50": "Eco 50 °C",
+          "program_intensive_70": "Intensivo 70 °C",
+          "program_eco_50": "Eco 50 °C",
           "program_glasscare": "GlassCare",
           "program_new58min": "Quick&Clean",
           "program_30min": "Mini 30'",
@@ -232,10 +255,10 @@
       "dishwasher_program": {
         "name": "Programa",
         "state": {
-          "program_auto": "40-65 °C automático",
+          "program_auto": "40-65 °C automático",
           "program_aqua_flex": "PROGRAM_AQUA_FLEX",
-          "program_intensive_70": "Intensivo 70 °C",
-          "program_eco_50": "Eco 50 °C",
+          "program_intensive_70": "Intensivo 70 °C",
+          "program_eco_50": "Eco 50 °C",
           "program_delicate": "Delicado",
           "program_quick_and_shine": "PROGRAM_QUICK_AND_SHINE",
           "program_mini": "PROGRAM_MINI",
@@ -307,11 +330,11 @@
       "state": {
         "name": "Estado",
         "state": {
-          "device_state_on": "Encendido",
-          "device_state_off": "Apagado",
-          "device_state_running": "En ejecución",
-          "device_state_paused": "En pausa",
-          "device_state_time_delay_active": "Retardo activo",
+          "device_state_on": "Encendida",
+          "device_state_off": "Apagada",
+          "device_state_running": "En marcha",
+          "device_state_paused": "Pausada",
+          "device_state_time_delay_active": "Inicio diferido",
           "device_state_cancelling": "Cancelando",
           "device_state_door_open": "La puerta está abierta.",
           "device_state_settings": "Configuración"
@@ -320,31 +343,31 @@
       "washer_program": {
         "name": "Programa",
         "state": {
-          "program_cottons": "Algodones",
+          "program_cottons": "Algodón",
           "program_eco_40_60": "Eco 40-60",
           "program_synthetics": "Sintéticos",
-          "program_mini_mini14": "Xpress",
-          "program_wool_handwash": "Woollens",
-          "program_delicates": "PROGRAM_DELICATES",
-          "program_spin_pump": "Spin+Drain",
+          "program_mini_mini14": "Rápido 28/14 min",
+          "program_wool_handwash": "Lana / Lavado a mano",
+          "program_delicates": "Delicados",
+          "program_spin_pump": "Centrifugado + vaciado",
           "program_rinsing": "Aclarado",
-          "program_darkwash": "Ropa oscura (vaqueros)",
-          "program_outdoor_sports_goretex": "Deportes",
-          "program_stain": "Sintéticos seco plancha",
+          "program_darkwash": "Prendas oscuras / Jeans",
+          "program_outdoor_sports_goretex": "Ropa exterior / deportiva",
+          "program_stain": "Manchas PRO",
           "program_hygeine": "Higiene+",
-          "program_duvet": "Edredón/plumón",
+          "program_duvet": "Plumíferos",
           "program_shirts": "Camisas",
           "program_drum_clean": "Limpieza del tambor",
-          "program_mix": "Combinado",
+          "program_mix": "Mixtos",
           "program_curtain": "Cortinas",
           "program_lingerie": "Lencería",
-          "program_soft_toys": "Peluches",
-          "program_towel": "Toalla",
+          "program_soft_toys": "Muñecos de peluche",
+          "program_towel": "Toallas",
           "program_cottons_eco": "Algodón Eco",
           "program_dryer_cotton": "Secado de algodón",
           "program_dryer_synthetics": "Secado de sintéticos",
           "program_hygiene_wash_dry": "Higiene + Wash & Dry",
-          "program_4kg_wash_dry": "Lavado y secado de 4 kg",
+          "program_4kg_wash_dry": "Lavado y secado de 4 kg",
           "program_wash_wear": "Wash & Wear",
           "program_dark_wash": "Lavado de ropa oscura",
           "program_outdoor": "Exteriores",
@@ -355,86 +378,109 @@
       "washer_temperature": {
         "name": "Temperatura",
         "state": {
-          "temperature_cold_wash": "Lavado en frío",
+          "temperature_cold_wash": "Fría",
           "temperature_20": "20 °C",
           "temperature_30": "30 °C",
           "temperature_40": "40 °C",
-          "60c": "60C",
-          "90c": "90C"
+          "60c": "60 °C",
+          "90c": "90 °C"
         }
       },
       "washer_spin": {
         "name": "Centrifugado",
         "state": {
           "spin_no_spin": "Sin centrifugado",
-          "600rpm": "600RPM",
-          "800rpm": "800RPM",
-          "1000rpm": "1000RPM",
-          "1200rpm": "1200RPM",
-          "spin_rinse_hold": "Remojo",
-          "spin_600": "600",
-          "spin_800": "800",
-          "spin_1200": "1200",
-          "spin_1400": "1400",
-          "1400rpm": "1400RPM"
+          "600rpm": "600 rpm",
+          "800rpm": "800 rpm",
+          "1000rpm": "1000 rpm",
+          "1200rpm": "1200 rpm",
+          "spin_rinse_hold": "Retención de aclarado",
+          "spin_600": "600 rpm",
+          "spin_800": "800 rpm",
+          "spin_1200": "1200 rpm",
+          "spin_1400": "1400 rpm",
+          "1400rpm": "1400 rpm"
         }
       },
       "washer_fast_plus": {
         "name": "Fast+",
         "state": {
-          "fast_plus_off": "Fast+ desactivado",
+          "fast_plus_off": "Desactivado",
           "fast_plus_on_fast": "Rápido",
           "fast_plus_on_fast_plus": "Fast+"
         }
       },
       "custom_duration_level": {
-        "name": "Nivel de duración personalizado",
+        "name": "Ajuste de duración",
         "state": {
-          "duration_level_0": "DURATION_LEVEL_0",
-          "1": "1",
-          "2": "2",
-          "3": "3",
-          "4": "4",
-          "5": "5",
-          "6": "6",
-          "7": "7",
-          "8": "8",
-          "9": "9",
-          "10": "10",
-          "11": "11"
+          "duration_level_0": "Nivel 0",
+          "1": "Nivel 1",
+          "2": "Nivel 2",
+          "3": "Nivel 3",
+          "4": "Nivel 4",
+          "5": "Nivel 5",
+          "6": "Nivel 6",
+          "7": "Nivel 7",
+          "8": "Nivel 8",
+          "9": "Nivel 9",
+          "10": "Nivel 10",
+          "11": "Nivel 11"
         }
       },
       "washer_extra_rinse_count": {
         "name": "Número de aclarados adicionales"
       },
       "settings_volume": {
-        "name": "Botón de volumen",
+        "name": "Volumen",
         "state": {
           "volume_low": "Bajo",
           "volume_high": "Alto"
         }
       },
+      "washer_hidden_anti_crease": {
+        "name": "Antiarrugas+",
+        "state": {
+          "hidden_anti_crease_off_0": "Desactivado",
+          "hidden_anti_crease_on_1": "Activado"
+        }
+      },
+      "settings_detergent_dosing_quantity": {
+        "name": "Cantidad de detergente",
+        "state": {
+          "quantity_low": "Baja",
+          "quantity_medium": "Media",
+          "quantity_high": "Alta"
+        }
+      },
+      "settings_softener_dosing_quantity": {
+        "name": "Cantidad de suavizante",
+        "state": {
+          "quantity_low": "Baja",
+          "quantity_medium": "Media",
+          "quantity_high": "Alta"
+        }
+      },
       "sub_state": {
         "name": "Subestado",
         "state": {
-          "washer_substate_washing": "Lavado",
-          "washer_substate_spin": "Centrifugado",
-          "washer_water_intake": "Entrada de agua",
-          "washer_substate_prewash": "Prelavar",
-          "washer_substate_rinsing": "Aclarado",
-          "washer_substate_softener": "Suavizante",
-          "washer_substate_program_started": "Programa iniciándose",
-          "washer_substate_time_delay_enabled": "Hora de finalización activada",
-          "washer_substate_paused": "Pausa",
-          "washer_substate_analysing": "Analizando",
+          "washer_substate_washing": "Lavando",
+          "washer_substate_spin": "Centrifugando",
+          "washer_water_intake": "Cargando agua",
+          "washer_substate_prewash": "Prelavando",
+          "washer_substate_rinsing": "Aclarando",
+          "washer_substate_softener": "Añadiendo suavizante",
+          "washer_substate_program_started": "Iniciando programa",
+          "washer_substate_time_delay_enabled": "Inicio diferido activado",
+          "washer_substate_paused": "Pausada",
+          "washer_substate_analysing": "Analizando la carga",
           "washer_substate_door_locked": "Puerta bloqueada",
           "washer_substate_opening_door": "Abriendo la puerta",
           "washer_substate_locking_door": "Bloqueando la puerta",
-          "washer_substate_remove_laundry": "Ciclo de lavado completo; retire la colada",
-          "washer_substate_add_laundry": "Puede añadir la colada",
-          "washer_substate_rinse_hold": "La función remojo está activa; seleccione la velocidad de centrifugado",
-          "washer_substate_remote_anticrease": "Antiarrugas remoto en curso.",
-          "washer_substate_drying": "Secado",
+          "washer_substate_remove_laundry": "Lavado terminado; retira la colada",
+          "washer_substate_add_laundry": "Puedes añadir prendas",
+          "washer_substate_rinse_hold": "Retención de aclarado activa",
+          "washer_substate_remote_anticrease": "Antiarrugas+ en curso",
+          "washer_substate_drying": "Secando",
           "oven_message_good_appetite": "Buen provecho",
           "oven_message_cooking": "Cocinando",
           "oven_message_paused": "En pausa",
@@ -479,13 +525,10 @@
         "name": "Seguridad"
       },
       "washer_prewash": {
-        "name": "Prelavar"
+        "name": "Prelavado"
       },
       "washer_extrarinse": {
         "name": "Aclarado adicional"
-      },
-      "washer_hidden_anti_crease": {
-        "name": "Antiarrugas inteligente"
       },
       "washer_steam": {
         "name": "Vapor"
@@ -497,13 +540,13 @@
         "name": "Agua adicional"
       },
       "washer_soaking": {
-        "name": "Remojando"
+        "name": "Remojo"
       },
       "washer_night": {
         "name": "Modo nocturno"
       },
       "washer_anticrease": {
-        "name": "AntiCrease"
+        "name": "Antiarrugas+"
       },
       "oven_program": {
         "name": "Programa",
@@ -558,10 +601,10 @@
       "program": {
         "name": "Programa",
         "state": {
-          "program_auto": "40-65 °C automático",
+          "program_auto": "40-65 °C automático",
           "program_mix_wash_plus": "All-in-Wash",
-          "program_intensive_70": "Intensivo 70 °C",
-          "program_eco_50": "Eco 50 °C",
+          "program_intensive_70": "Intensivo 70 °C",
+          "program_eco_50": "Eco 50 °C",
           "program_glasscare": "GlassCare",
           "program_new58min": "Quick&Clean",
           "program_30min": "Mini 30'",
@@ -640,10 +683,10 @@
       "dishwasher_program": {
         "name": "Programa",
         "state": {
-          "program_auto": "40-65 °C automático",
+          "program_auto": "40-65 °C automático",
           "program_aqua_flex": "PROGRAM_AQUA_FLEX",
-          "program_intensive_70": "Intensivo 70 °C",
-          "program_eco_50": "Eco 50 °C",
+          "program_intensive_70": "Intensivo 70 °C",
+          "program_eco_50": "Eco 50 °C",
           "program_delicate": "Delicado",
           "program_quick_and_shine": "PROGRAM_QUICK_AND_SHINE",
           "program_mini": "PROGRAM_MINI",
@@ -733,6 +776,12 @@
       "remote_control": {
         "name": "Control remoto"
       },
+      "washer_warning_low_detergent": {
+        "name": "Detergente bajo"
+      },
+      "washer_warning_low_softener": {
+        "name": "Suavizante bajo"
+      },
       "washer_warning_door_is_open": {
         "name": "La puerta está abierta"
       },
@@ -779,14 +828,20 @@
       }
     },
     "switch": {
+      "washer_liquid_detergent": {
+        "name": "Usar detergente líquido"
+      },
+      "washer_softener_dosage": {
+        "name": "Usar suavizante"
+      },
       "washer_prewash": {
-        "name": "Prelavar"
+        "name": "Prelavado"
       },
       "washer_extrarinse": {
         "name": "Aclarado adicional"
       },
       "washer_hidden_anti_crease": {
-        "name": "Antiarrugas inteligente"
+        "name": "Antiarrugas+"
       },
       "washer_steam": {
         "name": "Vapor"
@@ -798,13 +853,13 @@
         "name": "Agua adicional"
       },
       "washer_soaking": {
-        "name": "Remojando"
+        "name": "Remojo"
       },
       "washer_night": {
         "name": "Modo nocturno"
       },
       "washer_anticrease": {
-        "name": "AntiCrease"
+        "name": "Antiarrugas+"
       },
       "oven_booster": {
         "name": "Booster"


### PR DESCRIPTION
## Summary

This pull request corrects and completes the Spanish translations for washing machine entities and options.

The existing Spanish file contains several untranslated, incorrectly translated, or unrelated labels, including:

- `Woollens`
- `PROGRAM_DELICATES`
- `Spin+Drain`
- `Sintéticos seco plancha` for `program_stain`
- `DURATION_LEVEL_0`
- Raw values such as `quantity_low`
- Raw anti-crease values

## Changes

- Corrected washing programme names using the official Spanish terminology.
- Improved washer state and substate translations.
- Added readable detergent and softener dosage levels.
- Added translations for the hidden AntiCrease options.
- Corrected temperature and spin-speed formatting.
- Changed state descriptions to agree grammatically with “lavadora”, for example `Apagada`, `Encendida` and `Pausada`.

## Tested device

- Beko WTA 8612 XW DR
- Product code: 7161144000
- HomeWhiz Bluetooth connection through Home Assistant

## Reference

The terminology was checked against the official Spanish user manual for the Beko WTA 8612 XW DR:

https://www.beko.com/content/dam/spain-es-aem/spain-es-aemProductCatalog/product-documents/7161144000-WTA-8612-XW-DR/es-ES-7161144000-Manual-7161144000-es-ES20210226-121213-877.pdf