### PR TITLE
Stop dropping entities that share a unique ID

### DIFF
--- a/custom_components/homewhiz/appliance_controls.py
+++ b/custom_components/homewhiz/appliance_controls.py
@@ -1285,6 +1285,10 @@ def generate_controls_from_config(
             key,
             len(tmp_controls),
         )
-        controls[key] = extract_ac_control(tmp_controls)
+        # Preserve AC selection before removing duplicate entity controls.
+        unique_controls: dict[tuple[type[Control], str], Control] = {}
+        for control in extract_ac_control(tmp_controls):
+            unique_controls.setdefault((type(control), control.key), control)
+        controls[key] = list(unique_controls.values())
 
     return controls[key]

--- a/custom_components/homewhiz/tests/test_ac.py
+++ b/custom_components/homewhiz/tests/test_ac.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest import TestCase
 
@@ -13,6 +14,8 @@ from homeassistant.components.climate import (  # type: ignore[import]
 from custom_components.homewhiz.appliance_config import ApplianceConfiguration
 from custom_components.homewhiz.appliance_controls import (
     ClimateControl,
+    WriteNumericControl,
+    forget_controls,
     generate_controls_from_config,
 )
 from custom_components.homewhiz.homewhiz import Command
@@ -129,3 +132,42 @@ def test_hvac_control(config: ApplianceConfiguration) -> None:
             HVACMode.OFF,
         ],
     )
+
+
+@pytest.mark.parametrize("later_indices", [(77,), (77, 88)])
+def test_duplicate_ac_target_keeps_existing_selection(
+    config: ApplianceConfiguration, later_indices: tuple[int, ...]
+) -> None:
+    assert config.subPrograms is not None
+    target = next(
+        f
+        for f in config.subPrograms
+        if f.strKey == "AIR_CONDITIONER_TARGET_TEMPERATURE"
+    )
+    config = replace(
+        config,
+        settings=[
+            replace(target, wifiArrayIndex=index, wfaWriteIndex=index + 1)
+            for index in later_indices
+        ],
+    )
+    key = f"ac-duplicate-target-{later_indices}"
+    try:
+        generated = generate_controls_from_config(key, config)
+        assert [(type(c), c.key) for c in generated] == [
+            (WriteNumericControl, "air_conditioner_target_temperature"),
+            (ClimateControl, "ac"),
+        ]
+        standalone, climate = generated
+        assert isinstance(standalone, WriteNumericControl)
+        assert isinstance(climate, ClimateControl)
+        # HA retains the first standalone entity, while AC extraction uses the
+        # last configured target. Dedup must preserve both existing selections.
+        assert standalone.read_index == target.wifiArrayIndex
+        assert standalone.set_value(24) == Command(target.wifiArrayIndex, 24)
+        assert climate.target_temperature.read_index == later_indices[-1]
+        assert climate.target_temperature.set_value(24) == Command(
+            later_indices[-1] + 1, 24
+        )
+    finally:
+        forget_controls(key)

--- a/custom_components/homewhiz/tests/test_controls.py
+++ b/custom_components/homewhiz/tests/test_controls.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import replace
 from pathlib import Path
 from unittest import TestCase
 
@@ -11,6 +12,7 @@ from custom_components.homewhiz.appliance_config import (
 )
 from custom_components.homewhiz.appliance_controls import (
     EnumControl,
+    WriteBooleanControl,
     WriteEnumControl,
     WriteTimeControl,
     build_control_from_program,
@@ -163,3 +165,51 @@ def test_forget_controls_removes_the_cached_entry(
 
 def test_forget_controls_on_unknown_key_is_a_no_op() -> None:
     forget_controls("never-generated")
+
+
+def test_duplicate_controls_keep_first_occurrence_and_order(
+    config: ApplianceConfiguration,
+) -> None:
+    assert config.subPrograms is not None
+    steam = next(f for f in config.subPrograms if f.strKey == "WASHER_STEAM")
+    # Issue #452: one feature appears in two config branches. Different indices
+    # make retaining the wrong occurrence observable, not just its key.
+    duplicate_config = ApplianceConfiguration(
+        subPrograms=[steam, replace(steam, strKey="WASHER_OTHER")],
+        settings=[replace(steam, wifiArrayIndex=98, wfaWriteIndex=99)],
+    )
+    key = "test-duplicate-controls"
+    try:
+        generated = generate_controls_from_config(key, duplicate_config)
+        # Assert on the list: a dict keyed by control.key would hide the bug.
+        assert [(type(c), c.key) for c in generated] == [
+            (WriteBooleanControl, "washer_steam"),
+            (WriteBooleanControl, "washer_other"),
+        ]
+        first = generated[0]
+        assert isinstance(first, WriteBooleanControl)
+        assert first.read_index == steam.wifiArrayIndex
+        assert first.set_value(True) == Command(steam.wifiArrayIndex, 1)
+        assert first.set_value(False) == Command(steam.wifiArrayIndex, 0)
+        assert generate_controls_from_config(key, duplicate_config) is generated
+    finally:
+        forget_controls(key)
+
+
+def test_same_key_controls_of_different_classes_are_preserved(
+    config: ApplianceConfiguration,
+) -> None:
+    assert config.subPrograms is not None
+    steam = next(f for f in config.subPrograms if f.strKey == "WASHER_STEAM")
+    shared_key_config = ApplianceConfiguration(
+        subPrograms=[steam], monitorings=[steam], settings=[steam]
+    )
+    key = "test-shared-control-key"
+    try:
+        generated = generate_controls_from_config(key, shared_key_config)
+        assert [(type(c), c.key) for c in generated] == [
+            (WriteBooleanControl, "washer_steam"),
+            (EnumControl, "washer_steam"),
+        ]
+    finally:
+        forget_controls(key)


### PR DESCRIPTION
A feature declared in two config branches produces two controls with the same key, so Home Assistant registers the first and silently drops the second. Remove exact class/key duplicates from the generated list, keeping the first occurrence and the original order.

The deduplication runs after extract_ac_control, so the climate summary still sees the full list and keeps the target control it used before.

Reported and diagnosed by @souvir.

Fixes #452