### PR TITLE
Show a real error when picking a cloud appliance fails

### DIFF
--- a/custom_components/homewhiz/config_flow.py
+++ b/custom_components/homewhiz/config_flow.py
@@ -213,27 +213,34 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         assert self._cloud_credentials is not None
+        errors = {}
         if user_input is not None:
             assert self._cloud_appliances is not None
             appliance_id = user_input[CONF_ID]
             await self.async_set_unique_id(appliance_id)
+            # Outside the try: an already configured appliance must keep aborting
+            # the flow instead of being reported as an unexpected error.
             self._abort_if_unique_id_configured()
-            appliance = next(
-                a for a in self._cloud_appliances if a.applianceId == appliance_id
-            )
-            contents = await fetch_appliance_contents(
-                self._cloud_credentials, appliance_id
-            )
-            data = EntryData(
-                ids=IdExchangeResponse(appliance_id),
-                contents=contents,
-                appliance_info=appliance,
-                cloud_config=self._cloud_config,
-            )
-            return self.async_create_entry(
-                title=appliance.name,
-                data=asdict(data),
-            )
+            try:
+                appliance = next(
+                    a for a in self._cloud_appliances if a.applianceId == appliance_id
+                )
+                contents = await fetch_appliance_contents(
+                    self._cloud_credentials, appliance_id
+                )
+                data = EntryData(
+                    ids=IdExchangeResponse(appliance_id),
+                    contents=contents,
+                    appliance_info=appliance,
+                    cloud_config=self._cloud_config,
+                )
+                return self.async_create_entry(
+                    title=appliance.name,
+                    data=asdict(data),
+                )
+            except Exception:  # broad catch: without it the user gets no message at all
+                _LOGGER.exception("Cloud device setup failed unexpectedly")
+                errors["base"] = "unknown"
 
         if self._cloud_appliances is None:
             self._cloud_appliances = await fetch_appliance_infos(
@@ -252,6 +259,7 @@ class TiltConfigFlow(ConfigFlow, domain=DOMAIN):  # type: ignore[call-arg]
         return self.async_show_form(
             step_id="select_cloud_device",
             data_schema=vol.Schema({vol.Required(CONF_ID): vol.In(options)}),
+            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/homewhiz/tests/test_config_flow.py
+++ b/custom_components/homewhiz/tests/test_config_flow.py
@@ -9,11 +9,13 @@ list requires touching private attributes.
 
 import asyncio
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 
+from homeassistant.const import CONF_ID
 from homeassistant.data_entry_flow import FlowResultType
 
-from custom_components.homewhiz.api import ApplianceInfo
+from custom_components.homewhiz.api import ApplianceContents, ApplianceInfo
+from custom_components.homewhiz.appliance_config import ApplianceConfiguration
 from custom_components.homewhiz.config_flow import TiltConfigFlow
 
 
@@ -68,3 +70,49 @@ def test_cloud_devices_are_offered() -> None:
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "select_cloud_device"
+
+
+def _submittable_flow(appliances: list[ApplianceInfo]) -> TiltConfigFlow:
+    """The submit path calls Home Assistant's unique id helpers, which need a
+    running hass. Stub them so the test covers this step's own behaviour."""
+    flow = _make_flow(appliances)
+    flow.async_set_unique_id = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    flow._abort_if_unique_id_configured = Mock(return_value=None)  # type: ignore[method-assign]
+    return flow
+
+
+def test_failing_contents_fetch_shows_the_form_again() -> None:
+    """Issue #451 ended in this step with a traceback and a dead end."""
+    flow = _submittable_flow([_appliance("a1", "BTWIFI")])
+
+    with patch(
+        "custom_components.homewhiz.config_flow.fetch_appliance_contents",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        result = asyncio.run(flow.async_step_select_cloud_device({CONF_ID: "a1"}))
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "select_cloud_device"
+    assert result["errors"] == {"base": "unknown"}
+
+
+def test_retry_after_a_failed_fetch_still_creates_the_entry() -> None:
+    """The unique id is claimed before the fetch, so a second attempt in the
+    same flow must not be turned away."""
+    flow = _submittable_flow([_appliance("a1", "BTWIFI")])
+    contents = ApplianceContents(config=ApplianceConfiguration(), localization={})
+
+    with patch(
+        "custom_components.homewhiz.config_flow.fetch_appliance_contents",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        asyncio.run(flow.async_step_select_cloud_device({CONF_ID: "a1"}))
+
+    with patch(
+        "custom_components.homewhiz.config_flow.fetch_appliance_contents",
+        AsyncMock(return_value=contents),
+    ):
+        result = asyncio.run(flow.async_step_select_cloud_device({CONF_ID: "a1"}))
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Appliance a1"


### PR DESCRIPTION
async_step_select_cloud_device was the only setup step without a broad catch, so anything raised after the user picked an appliance ended the flow with Home Assistant's generic error instead of the step's own message. Issue #451 hit exactly this path.

Wrap the submit branch like the two neighbouring steps do. _abort_if_unique_id_configured stays outside the try, so an already configured appliance keeps aborting instead of being reported as an unexpected error.